### PR TITLE
Add Domain when Indicator is added via Object creation

### DIFF
--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -350,6 +350,7 @@ def add_object(type_, oid, object_type, name, source, method,
                                                object_type,
                                                analyst,
                                                method=method,
+                                               add_domain=True,
                                                campaign=indicator_campaign,
                                                campaign_confidence=indicator_campaign_confidence,
                                                cache=cache)


### PR DESCRIPTION
When a domain or URL indicator is added using the standard indicator creation form, the domain is parsed out and added as a Domain in CRITs. This is also the case when clicking the '+' (Add Indicator) button next to an already existing Object. However, if the "Add Indicator" box of the Add Object form is selected during Object creation, the Domain is not parsed out and added. This behavior is inconsistent.
