### PR TITLE
Make generic the best-effort parsing of HELO from a .msg

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -1483,7 +1483,11 @@ def parse_ole_file(file):
     last_from = ''
     helo_for = ''
     all_received = headers.get_all('Received')
-    email_domain = settings.CRITS_EMAIL.split('.')[-2]
+    crits_config = CRITsConfig.objects().first()
+    if crits_config:
+        email_domain = crits_config.crits_email.split('.')[-2]
+    else:
+        email_domain = ''
 
     if all_received:
         for received in all_received:


### PR DESCRIPTION
Some Boeing specific code needed to be cleaned up. This change will use the domain of the CRITs email address to do best-effort parsing of the HELO.
