### PR TITLE
Prevent File Bulk Objects

### DIFF
--- a/crits/objects/templates/bulk_add_object_inline.html
+++ b/crits/objects/templates/bulk_add_object_inline.html
@@ -12,7 +12,13 @@
     <button id="validate-{{ table_name }}-inline-table">Validate Table</button>
     <span id='custom_buttons'/>
 </div>
-<div id="{{ table_name }}_errors"></div>
+<br/>
+<div id="{{ table_name }}_errors">
+    <span>Note: Bulk Upload of "File" types is not supported.
+        You can still upload individual files (e.g. File, Artifact - File,
+        Artifact Network Traffic, and Network Flow through the single object creation form.
+    </span>
+</div>
 </div>
 
 <script type="text/javascript">

--- a/crits/objects/views.py
+++ b/crits/objects/views.py
@@ -144,7 +144,7 @@ def bulk_add_object(request):
                             c[0],
                             {'datatype':c[1].keys()[0],
                             'datatype_value':c[1].values()[0]}
-                            ) for c in get_object_types(False)]
+                            ) for c in get_object_types(False, query={'datatype.file':{'$exists':0}})]
 
     formdict = form_to_dict(AddObjectForm(request.user, all_obj_type_choices))
 
@@ -172,7 +172,7 @@ def bulk_add_object_inline(request):
     """
     all_obj_type_choices = [(c[0], c[0], {'datatype':c[1].keys()[0],
                             'datatype_value':c[1].values()[0]}
-                            ) for c in get_object_types(False)]
+                            ) for c in get_object_types(False, query={'datatype.file':{'$exists':0}})]
 
     formdict = form_to_dict(AddObjectForm(request.user, all_obj_type_choices))
 


### PR DESCRIPTION
There is an issue where bulk uploading a "file" object type causes details pages to error on a url lookup for a file md5 in the object_listing_row_widget.html template. This is because objects bulk upload only takes in a string for the "Value" while the normal object upload form takes in a local file path. Would need a click event for file browsing in handsontable, then ajax upload both json and file data which seems like a pain.

For now disable the "file" object uploads and add a note saying that object file uploads are not supported and that users can use the normal object upload form if they want to upload files.
