### PR TITLE
Fix Redirect for Rerunnable Services with no Config Options

### DIFF
--- a/crits/services/views.py
+++ b/crits/services/views.py
@@ -397,8 +397,8 @@ def get_form(request, name, crits_type, identifier):
     if not ServiceRunConfigForm:
         # this should only happen if there are no config options and the
         # service is rerunnable.
-        response['redirect'] = reverse('crits.services.views.service_run',
-                                        args=[name, crits_type, identifier])
+        return redirect(reverse('crits.services.views.service_run',
+                                args=[name, crits_type, identifier]))
     else:
         form = ServiceRunConfigForm(dict(config))
         response['form'] = render_to_string("services_run_form.html",


### PR DESCRIPTION
I think this is a bug preventing rerunnable services without non-private config fields from running via the service_run_button on the object analysis page. If there is a reason why this was being returned as a response field, please let me know.
