### PR TITLE
Allow for custom service runtime forms.

### DIFF
--- a/crits/services/views.py
+++ b/crits/services/views.py
@@ -378,6 +378,7 @@ def get_form(request, name, crits_type, identifier):
 
     response = {}
     response['name'] = name
+    analyst = request.user.username
 
     service = CRITsService.objects(name=name,
                                    status__ne="unavailable").first()
@@ -393,19 +394,20 @@ def get_form(request, name, crits_type, identifier):
     # format_config returns a list of tuples
     config = service_class.format_config(service.config, printable=False)
 
-    ServiceRunConfigForm = make_run_config_form(service_class)
-    if not ServiceRunConfigForm:
+    form_html = make_run_config_form(service_class,
+                                     config,
+                                     name,
+                                     request,
+                                     analyst=analyst,
+                                     crits_type=crits_type,
+                                     identifier=identifier)
+    if not form_html:
         # this should only happen if there are no config options and the
         # service is rerunnable.
         response['redirect'] = reverse('crits.services.views.service_run',
                                         args=[name, crits_type, identifier])
     else:
-        form = ServiceRunConfigForm(dict(config))
-        response['form'] = render_to_string("services_run_form.html",
-                                    {'name': name, 'form': form,
-                                    'crits_type': crits_type,
-                                    'identifier': identifier},
-                                    RequestContext(request))
+        response['form'] = form_html
 
     return HttpResponse(json.dumps(response), mimetype="application/json")
 
@@ -471,8 +473,23 @@ def service_run(request, name, crits_type, identifier):
         response['html'] = "Error: %s" % e
         return HttpResponse(json.dumps(response), mimetype="application/json")
 
+    service = CRITsService.objects(name=name,
+                                   status__ne="unavailable").first()
+    if not service:
+        msg = 'Service "%s" is unavailable. Please review error logs.' % name
+        response['error'] = msg
+        return HttpResponse(json.dumps(response), mimetype="application/json")
+
     service_class = env.manager.get_service_class(name)
-    ServiceRunConfigForm = make_run_config_form(service_class)
+    config = service_class.format_config(service.config, printable=False)
+    ServiceRunConfigForm = make_run_config_form(service_class,
+                                                config,
+                                                name,
+                                                request,
+                                                analyst=username,
+                                                crits_type=crits_type,
+                                                identifier=identifier,
+                                                return_form=True)
 
     if request.method == "POST":
         #Populate the form with values from the POST request


### PR DESCRIPTION
Runtime forms were always based on the configuration options provided
for the Control Panel. This change allows you to fully customize the
service runtime form, including having your own template so you can
include javascript and such to make the form more interactive.

If you wish to leverage this capability, your service now needs to have
a "generate_runtime_form()" which should take the following as
arguments:
- self
- analyst
- name
- crits_type
- identifier

You don't need to use any of that information if it's not necessary, but
it will be passed along by services (for the time being). This function
needs to return two things:
- a Django form object
- HTML of the rendered form

The former can be None if there is no Django-style form to generate. The
latter should be the rendered HTML form (you can use render_to_string()
with your own custom form template). If you want your own template,
create it in the "templates" directory of your service, give it a unique
name, and reference it appropriately in your function.

If you want to test this out, I did the following:
- copy `services_run_form.html` to `pyew/templates/pyew_run_form.html`for the Pyew service.
- edit the `pyew_run_form.html` file and change `form.as_table` to `form`
- add the following method to the Service class in `pyew/__init__.py`:

``` python
    def generate_runtime_form(self, analyst, name, crits_type, identifier):         
        form = render_to_string("pyew_run_form.html",                               
                                {'form': "<div><b>This is a form!</b></div>",       
                                 'name': name,                                      
                                 'crits_type': crits_type,                          
                                 'identifier': identifier})                         
        return None, form
```

Once you restart your web server (or run server) you should be able to go to any Sample, and on the Analysis tab click on "Pyew". Normally it wouldn't do anything, but with these changes you should get a form popup that says "This is a form!".
