### PR TITLE
Missing paramter in isinstance() call.

### DIFF
--- a/crits/screenshots/handlers.py
+++ b/crits/screenshots/handlers.py
@@ -135,7 +135,7 @@ def add_screenshot(description, tags, source, method, reference, analyst,
     final_screenshots = []
 
     if screenshot_ids:
-        if not isinstance(screenshot_ids):
+        if not isinstance(screenshot_ids, list):
             screenshot_list = screenshot_ids.split(',')
         else:
             screenshot_list = screenshot_ids


### PR DESCRIPTION
Missing paramter in isinstance() call.

Sidenote: the copy IDs on screenshots is not working for me on firefox/chrome. Not sure if it's just me.
