### PR TITLE
Fix Events jTable listing URL

### DIFF
--- a/crits/events/event.py
+++ b/crits/events/event.py
@@ -44,7 +44,7 @@ class Event(CritsBaseAttributes, CritsSourceDocument, Document):
                          'details_url': 'crits.events.views.view_event',
                          'details_url_key': 'id',
                          'default_sort': "created DESC",
-                         'searchurl': 'crits.emails.views.emails_listing',
+                         'searchurl': 'crits.events.views.events_listing',
                          'fields': [ "title", "event_type", "created",
                                      "source", "campaign", "status", "id"],
                          'jtopts_fields': [ "details",


### PR DESCRIPTION
Fix 'searchurl' option for events.  It was pointing to the emails listing which broke event jTables.
