### PR TITLE
Fix parse of domain from crits_email

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -32,6 +32,7 @@ from crits.core.handlers import build_jtable, jtable_ajax_list, jtable_ajax_dele
 from crits.core.handlers import csv_export
 from crits.core.user_tools import user_sources, is_admin, is_user_favorite
 from crits.core.user_tools import is_user_subscribed
+from crits.domains.handlers import get_domain
 from crits.emails import OleFileIO_PL
 from crits.emails.email import Email
 from crits.indicators.handlers import handle_indicator_ind
@@ -1490,7 +1491,7 @@ def parse_ole_file(file):
     all_received = headers.get_all('Received')
     crits_config = CRITsConfig.objects().first()
     if crits_config:
-        email_domain = crits_config.crits_email.split('.')[-2]
+        email_domain = get_domain(crits_config.crits_email.split('@')[-1])[0]
     else:
         email_domain = ''
 


### PR DESCRIPTION
Use the get_domain function in domains/handlers.py to parse the domain from the crits_email address using the built-in TLD list. This addresses a bug found during discussion of issue #134.
