### PR TITLE
Strip whitespace when creating Indicator from Object

### DIFF
--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -600,6 +600,9 @@ def create_indicator_from_object(rel_type, rel_id, ind_type, value, analyst,
         result = {'success':  False,
                   'message':  "Can't create indicator with an empty type field"}
     else:
+        value = value.lower().strip()
+        ind_type = ind_type.strip()
+        
         create_indicator_result = {}
         ind_tlist = ind_type.split(" - ")
         if ind_tlist[0] == ind_tlist[1]:


### PR DESCRIPTION
Before Indicators are added, they are converted to lowercase and whitespace is stripped. If this is not first done in the 'create_indicator_from_object' function, an Object with uppercase characters or leading/trailing whitespace will cause the relationship to not be formed because the Object value and Indicator value will not match.
