### PR TITLE
Strip leading/trailing whitespace before adding Objects

### DIFF
--- a/crits/objects/views.py
+++ b/crits/objects/views.py
@@ -67,6 +67,8 @@ def add_new_object(request):
         if 'value' in request.FILES:
             data = request.FILES['value']
         value = request.POST.get('value', None)
+        if isinstance(value, basestring):
+            value = value.strip()
         results = add_object(my_type,
                              oid,
                              object_type,


### PR DESCRIPTION
Copy and pasting often leads to leading/trailing whitespace making its way into form fields. Stripping that whitespace seems to help reduce the occurrence of frustrated analysts.
