### PR TITLE
Control Panel Clicking Issue and Padding

### DIFF
--- a/crits/core/templates/control_panel.html
+++ b/crits/core/templates/control_panel.html
@@ -38,11 +38,9 @@
     div#panel_sections ul.menu li {
         background: #eee;
     }
-    div#panel_sections ul.menu li.menu_item a {
+    div#panel_sections ul.menu li.menu_item a:hover {
         font-weight: bold;
         vertical-align: top;
-        padding-top: 1px;
-        padding: 5px 5px 5px 5px;
     }
     table#panel_table {
         height: 99%;


### PR DESCRIPTION
I can't be the only one that sees this issue. I've seen it for about the past half year and am finally going to fix this.

Go into CRITs control panel and on the left handside menu, hover your mouse on near the bottom of the text (e.g. Services). If you click the bottom part of the text, then the below menu will load instead (e.g. Audit Log instead of Services)

Fixing an issue with clicking on the Control Panel menu on the left handside. Clicking on the bottom 5 pixels does not load the right menu. Padding is weird and unnecessary. Making hovering highlighting obvious which menu is going to be loaded on click.
