### PR TITLE
Allow services to extend the API

### DIFF
--- a/crits/urls.py
+++ b/crits/urls.py
@@ -332,8 +332,8 @@ if settings.ENABLE_API:
                 abs_path = os.path.join(service_directory, d, 'urls.py')
                 if os.path.isfile(abs_path):
                     try:
-                        foo = imp.load_source('urls', abs_path)
-                        foo.register_api(v1_api)
+                        rdef = imp.load_source('urls', abs_path)
+                        rdef.register_api(v1_api)
                     except Exception, e:
                         pass
 


### PR DESCRIPTION
I am not 100% sure this is the most efficient way or place for this to happen (we do this loop again in the services/urls.py file), so please voice your opinion!

This allows services to extend the API. There are a few things the service needs to
do:

1) Create an 'api.py' file which contains the "Resource" they are using
for the API.
2) Create a 'urls.py' (if it doesn't already have one) and add a
function to it called "register_api()". The function should look like
this:

``` python
    def register_api(v1_api):
        from my_service.api import MyServiceResource
        v1_api.register(MyServiceResource())
```

When the API registers its URLs your service's API URLs will be
included.

One thing to keep in mind is that your service will most likely already
have a MongoEngine class for handling its own collection in the
database. You should use that class in your Resource. If your service
works on a specific CRITs top-level object, you might need that class.
If it works on multiple top-level objects, have fun :)
