### PR TITLE
Use Object Source when adding Indicator from an Object

### DIFF
--- a/crits/objects/static/js/objects.js
+++ b/crits/objects/static/js/objects.js
@@ -278,6 +278,9 @@ $(document).ready(function() {
         var me = $(this);
         var guardian = me.closest("tr");
         var value = $(guardian).attr('vvalue');
+        var source = $(guardian).find("span[name='source_name']").attr('sname');
+        var method = $(guardian).find("span[name='source_method']").attr('method');
+        var reference = $(guardian).find("span[name='source_reference']").attr('reference');
 
         // Might be nicer if this was a spinning icon, but working with what we have handy
         me.removeClass('ui-icon-plus');
@@ -290,6 +293,9 @@ $(document).ready(function() {
             'value': value,
             'rel_type': my_type,
             'rel_id': my_id,
+            'source': source,
+            'method': method,
+            'reference': reference,
         };
         $.ajax({
             type: "POST",

--- a/crits/objects/views.py
+++ b/crits/objects/views.py
@@ -440,11 +440,17 @@ def indicator_from_object(request):
         rel_id = request.POST.get('rel_id', None)
         ind_type = request.POST.get('ind_type', None)
         value = request.POST.get('value', None)
+        source = request.POST.get('source', None)
+        method = request.POST.get('method', None)
+        reference = request.POST.get('reference', None)
         analyst = "%s" % request.user.username
         result = create_indicator_from_object(rel_type,
                                               rel_id,
                                               ind_type,
                                               value,
+                                              source,
+                                              method,
+                                              reference,
                                               analyst,
                                               request)
         return HttpResponse(json.dumps(result),

--- a/extras/www/static/js/objects.js
+++ b/extras/www/static/js/objects.js
@@ -278,6 +278,9 @@ $(document).ready(function() {
         var me = $(this);
         var guardian = me.closest("tr");
         var value = $(guardian).attr('vvalue');
+        var source = $(guardian).find("span[name='source_name']").attr('sname');
+        var method = $(guardian).find("span[name='source_method']").attr('method');
+        var reference = $(guardian).find("span[name='source_reference']").attr('reference');
 
         // Might be nicer if this was a spinning icon, but working with what we have handy
         me.removeClass('ui-icon-plus');
@@ -290,6 +293,9 @@ $(document).ready(function() {
             'value': value,
             'rel_type': my_type,
             'rel_id': my_id,
+            'source': source,
+            'method': method,
+            'reference': reference,
         };
         $.ajax({
             type: "POST",


### PR DESCRIPTION
When creating a new Object and selecting the "Add Indicator" checkbox, the newly created Indicator uses the Source information entered in the Add Object form. However, when creating an Indicator from an already existing Object via the "+" button, the top-level object's Source was used instead. This fixes that inconsistency.
