### PR TITLE
Allow user names to be email addresses

### DIFF
--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -870,8 +870,10 @@ class CRITsAuthBackend(object):
         fusername = username
         if '\\' in username:
             username = username.split("\\")[1]
-        elif "@" in username:
-            username = username.split("@")[0]
+        # Comment out to allow email addresses to be specified
+        #elif "@" in username:
+        #    username = username.split("@")[0]
+
         user = CRITsUser.objects(username=username).first()
         if user:
             # If the user needs TOTP and it is not disabled system-wide, and


### PR DESCRIPTION
It is very common across enterprises to use email addresses as userid.
Removing the split when there is an @ in the user name allows for this
