### PR TITLE
Give samples ability to have multiple filenames.

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1368,7 +1368,10 @@ def gen_global_query(obj,user,term,search_type="global",force_full=False):
         'ssdeephash': {'ssdeep': search_query},
         'sha256hash': {'sha256': search_query},
         # slow in larger collections
-        'filename': {'filename': search_query},
+        'filename': {'$or': [
+            {'filename': search_query},
+            {'filenames': search_query},
+        ]},
         'exploit': {'exploit.cve': search_query},
         'campaign': {'campaign.name': search_query},
         # slightly slow in larger collections

--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -991,6 +991,9 @@ def handle_file(filename, data, source, reference=None, parent_md5=None,
         sample = Sample()
         sample.filename = filename or md5_digest
         sample.md5 = md5_digest
+    else:
+        if filename not in sample.filenames and filename != sample.filename:
+            sample.filenames.append(filename)
 
         if cached_results != None:
             cached_results[md5_digest] = sample
@@ -1507,3 +1510,52 @@ def process_bulk_add_md5_sample(request, formdict):
     response = parse_bulk_upload(request, parse_row_to_bound_md5_sample_form, add_new_sample_via_bulk, formdict, cache)
 
     return response
+
+def update_sample_filename(id_, filename, analyst):
+    """
+    Update a Sample filename.
+
+    :param id_: ObjectId of the Sample.
+    :type id_: str
+    :param filename: The new filename.
+    :type filename: str
+    :param analyst: The user setting the new filename.
+    :type analyst: str
+    :returns: dict with key 'success' (boolean) and 'message' (str) if failed.
+    """
+
+    if not filename:
+        return {'success': False, 'message': "No filename to change"}
+    sample = Sample.objects(id=id_).first()
+    if not sample:
+        return {'success': False, 'message': "No sample to change"}
+    sample.filename = filename.strip()
+    try:
+        sample.save(username=analyst)
+        return {'success': True}
+    except ValidationError, e:
+        return {'success': False, 'message': e}
+
+def modify_sample_filenames(id_, tags, analyst):
+    """
+    Modify the filenames for a Sample.
+
+    :param id_: ObjectId of the Sample.
+    :type id_: str
+    :param tags: The new filenames.
+    :type tags: list
+    :param analyst: The user setting the new filenames.
+    :type analyst: str
+    :returns: dict with key 'success' (boolean) and 'message' (str) if failed.
+    """
+
+    sample = Sample.objects(id=id_).first()
+    if sample:
+        sample.set_filenames(tags)
+        try:
+            sample.save(username=analyst)
+            return {'success': True}
+        except ValidationError, e:
+            return {'success': False, 'message': "Invalid value: %s" % e}
+    else:
+        return {'success': False}

--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -39,6 +39,7 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, Document):
         "schema_doc": {
             'filename': 'The name of the last file that was uploaded with this'\
                 'MD5',
+            'filenames': 'A list of filenames this binary has gone by.',
             'filetype': 'The filetype of the file',
             'mimetype': 'The mimetype of the file',
             'size': 'The size of the file',
@@ -97,6 +98,7 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, Document):
     exploit = ListField(EmbeddedDocumentField(EmbeddedExploit))
     filedata = getFileField(collection_name=settings.COL_SAMPLES)
     filename = StringField(required=True)
+    filenames = ListField(StringField())
     filetype = StringField()
     md5 = StringField(required=True)
     mimetype = StringField()
@@ -252,3 +254,15 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, Document):
             if e.cve == cve:
                 del self.exploit[c]
             c += 0
+
+    def set_filenames(self, filenames):
+        """
+        Set the Sample filenames to a specified list.
+
+        :param filenames: The filenames to set.
+        :type filenames: list
+
+        """
+
+        if isinstance(filenames, list):
+            self.filenames = filenames

--- a/crits/samples/static/js/samples.js
+++ b/crits/samples/static/js/samples.js
@@ -134,6 +134,78 @@ $(document).ready(function(){
     $('#form-add-comment-static').submit(function(e) {
         addEditSubmit(e);
     });
+
+    $('#sample_filename').editable(function(value, settings) {
+        var revert = this.revert;
+        return function(value, settings, elem) {
+            var data = {
+                'filename': value,
+                'id': sample_id_escaped,
+            };
+            $.ajax({
+                type: "POST",
+                async: false,
+                url: update_sample_filename,
+                data: data,
+                success: function(data) {
+                    if (!data.success) {
+                        value = revert;
+                        $('#sample_filename_error').text(data.message);
+                    }
+                }
+            });
+            return value;
+        }(value, settings, this);
+        },
+        {
+            type: 'textarea',
+            width: "400px",
+            tooltip: "",
+            cancel: "Cancel",
+            submit: "Ok",
+            onblur: 'ignore',
+    });
+    $("#sample_filenames").tagit({
+        allowSpaces: true,
+        removeConfirmation: false,
+        afterTagAdded: function(event, ui) {
+            var my_tags = $("#sample_filenames").tagit("assignedTags");
+            update_filenames(my_tags);
+        },
+        beforeTagRemoved: function(event, ui) {
+            if (is_admin != "True") {
+                return false;
+            }
+        },
+        afterTagRemoved: function(event, ui) {
+            var my_tags = $("#sample_filenames").tagit("assignedTags");
+            update_filenames(my_tags);
+        },
+    });
+
+    function update_filenames(my_tags) {
+        if (window.add_filenames) {
+            var data = {
+                        'id': sample_id_escaped,
+                        'tags': my_tags.toString(),
+            };
+            $.ajax({
+                type: "POST",
+                url: update_sample_filenames,
+                data: data,
+                datatype: 'json',
+                success: function(data) {
+                    if (!data.success) {
+                        alert("Failed to update filenames!");
+                    }
+                }
+            });
+        }
+    }
+
+    $(document).trigger('enable_filenames');
+
     details_copy_id('Sample');
     toggle_favorite('Sample');
+
 });

--- a/crits/samples/templates/samples_detail.html
+++ b/crits/samples/templates/samples_detail.html
@@ -12,6 +12,8 @@
     var get_hex = "{% url 'crits.samples.views.hex' sample.md5 %}";
     var xor_search = "{% url 'crits.samples.views.xor_searcher' sample.md5 %}";
     var get_xor = "{% url 'crits.samples.views.xor' sample.md5 %}?key=";
+    var update_sample_filename = "{% url 'crits.samples.views.set_sample_filename' %}";
+    var update_sample_filenames = "{% url 'crits.samples.views.set_sample_filenames' %}";
 </script>
 
 {% if sample %}
@@ -51,7 +53,20 @@
             </tr>
             <tr>
                 <td class="key">Filename</td>
-                <td>{{ sample.filename }}</td>
+                <td>
+                    <span class="edit_underline" id="sample_filename">{{ sample.filename }}</span>
+                    <span id="sample_filename_error"></span>
+                </td>
+            </tr>
+            <tr>
+                <td class="key">Filenames</td>
+                <td>
+                    <ul id="sample_filenames">
+                        {% for filename in sample.filenames %}
+                            <li>{{ filename }}</li>
+                        {% endfor %}
+                    </ul>
+                </td>
             </tr>
             <tr>
                 <td class="key">Filetype</td>
@@ -221,6 +236,13 @@
 </div>
 
 </div>
+
+
+<script>
+    $(document).bind('enable_filenames', function(){
+        window.add_filenames = true;
+    });
+</script>
 
 {% else %}
 <h1>Missing sample.</h1>

--- a/crits/samples/views.py
+++ b/crits/samples/views.py
@@ -30,6 +30,7 @@ from crits.samples.handlers import add_backdoor_to_sample, get_source_counts
 from crits.samples.handlers import get_sample_details, generate_backdoor_jtable
 from crits.samples.handlers import generate_sample_jtable, add_source_to_samples
 from crits.samples.handlers import generate_sample_csv, process_bulk_add_md5_sample
+from crits.samples.handlers import update_sample_filename, modify_sample_filenames
 from crits.samples.sample import Sample
 from crits.stats.handlers import generate_sources
 from crits.stats.handlers import generate_exploits
@@ -731,4 +732,50 @@ def remove_sample(request, md5):
     else:
         return render_to_response('error.html',
                                   {'error': "Could not delete sample"},
+                                  RequestContext(request))
+
+@user_passes_test(user_can_view_data)
+def set_sample_filename(request):
+    """
+    Set a Sample filename. Should be an AJAX POST.
+
+    :param request: Django request object (Required)
+    :type request: :class:`django.http.HttpRequest`
+    :returns: :class:`django.http.HttpResponse`
+    """
+
+    if request.method == 'POST':
+        filename = request.POST.get('filename', None)
+        id_ = request.POST.get('id', None)
+        analyst = request.user.username
+        return HttpResponse(json.dumps(update_sample_filename(id_,
+                                                              filename,
+                                                              analyst)),
+                            mimetype="application/json")
+    else:
+        error = "Expected POST"
+        return render_to_response("error.html",
+                                  {"error" : error },
+                                  RequestContext(request))
+
+@user_passes_test(user_can_view_data)
+def set_sample_filenames(request):
+    """
+    Set Sample filenames. Should be an AJAX POST.
+
+    :param request: Django request object (Required)
+    :type request: :class:`django.http.HttpRequest`
+    :returns: :class:`django.http.HttpResponse`
+    """
+
+    if request.method == "POST" and request.is_ajax():
+        tags = request.POST.get('tags', "").split(",")
+        id_ = request.POST.get('id', None)
+        return HttpResponse(json.dumps(modify_sample_filenames(id_,
+                                                               tags,
+                                                               request.user.username)),
+                            mimetype="application/json")
+    else:
+        error = "Expected POST"
+        return render_to_response("error.html", {"error" : error },
                                   RequestContext(request))

--- a/crits/urls.py
+++ b/crits/urls.py
@@ -260,6 +260,8 @@ urlpatterns = patterns('',
         (r'^samples/backdoors/list/(?P<option>\S+)/$', 'crits.samples.views.backdoors_listing'),
         (r'^samples/yarahits/list/$', 'crits.samples.views.yarahits_listing'),
         (r'^samples/yarahits/list/(?P<option>\S+)/$', 'crits.samples.views.yarahits_listing'),
+        (r'^samples/set_filename/$', 'crits.samples.views.set_sample_filename'),
+        (r'^samples/filenames/$', 'crits.samples.views.set_sample_filenames'),
 
         # Screenshots
         (r'^screenshots/list/$', 'crits.screenshots.views.screenshots_listing'),

--- a/extras/www/static/js/samples.js
+++ b/extras/www/static/js/samples.js
@@ -134,6 +134,78 @@ $(document).ready(function(){
     $('#form-add-comment-static').submit(function(e) {
         addEditSubmit(e);
     });
+
+    $('#sample_filename').editable(function(value, settings) {
+        var revert = this.revert;
+        return function(value, settings, elem) {
+            var data = {
+                'filename': value,
+                'id': sample_id_escaped,
+            };
+            $.ajax({
+                type: "POST",
+                async: false,
+                url: update_sample_filename,
+                data: data,
+                success: function(data) {
+                    if (!data.success) {
+                        value = revert;
+                        $('#sample_filename_error').text(data.message);
+                    }
+                }
+            });
+            return value;
+        }(value, settings, this);
+        },
+        {
+            type: 'textarea',
+            width: "400px",
+            tooltip: "",
+            cancel: "Cancel",
+            submit: "Ok",
+            onblur: 'ignore',
+    });
+    $("#sample_filenames").tagit({
+        allowSpaces: true,
+        removeConfirmation: false,
+        afterTagAdded: function(event, ui) {
+            var my_tags = $("#sample_filenames").tagit("assignedTags");
+            update_filenames(my_tags);
+        },
+        beforeTagRemoved: function(event, ui) {
+            if (is_admin != "True") {
+                return false;
+            }
+        },
+        afterTagRemoved: function(event, ui) {
+            var my_tags = $("#sample_filenames").tagit("assignedTags");
+            update_filenames(my_tags);
+        },
+    });
+
+    function update_filenames(my_tags) {
+        if (window.add_filenames) {
+            var data = {
+                        'id': sample_id_escaped,
+                        'tags': my_tags.toString(),
+            };
+            $.ajax({
+                type: "POST",
+                url: update_sample_filenames,
+                data: data,
+                datatype: 'json',
+                success: function(data) {
+                    if (!data.success) {
+                        alert("Failed to update filenames!");
+                    }
+                }
+            });
+        }
+    }
+
+    $(document).trigger('enable_filenames');
+
     details_copy_id('Sample');
     toggle_favorite('Sample');
+
 });


### PR DESCRIPTION
Works similar to campaign aliases. There is one main filename (which can
now be modified in-line) which is the filename your organization prefers
that sample go by. There's also a list of filenames which are other
filenames people have reported that binary going by.

If you upload a Sample that already exists in the database, the filename
will get appended to the list of filenames if it isn't already the
filename or in the list of existing filenames.

Searching "Filename" in the advanced search for Samples now does a $or
between both fields so you will search both simultaneously.

Closes #5.
