### PR TITLE
Email as user name

### DIFF
--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -870,8 +870,6 @@ class CRITsAuthBackend(object):
         fusername = username
         if '\\' in username:
             username = username.split("\\")[1]
-       # elif "@" in username:
-       #     username = username.split("@")[0]
         user = CRITsUser.objects(username=username).first()
         if user:
             # If the user needs TOTP and it is not disabled system-wide, and


### PR DESCRIPTION
many enterprises use email addresses for user id's   this simple change allows for that. 
