### PR TITLE
Handle ldap search

### DIFF
--- a/crits/config/config.py
+++ b/crits/config/config.py
@@ -44,6 +44,10 @@ class CRITsConfig(CritsDocument, Document):
     ldap_tls = BooleanField(default=False)
     ldap_server = StringField(default='')
     ldap_usercn = StringField(default='')
+    #SAB Add for ldap searching
+    ldap_special = StringField(default='')
+    #SAB End Add
+
     ldap_userdn = StringField(default='')
     ldap_update_on_login = BooleanField(default=False)
     log_directory = StringField(default=os.path.join(settings.SITE_ROOT, 'logs'))

--- a/crits/config/forms.py
+++ b/crits/config/forms.py
@@ -82,6 +82,11 @@ class ConfigForm(forms.Form):
                                   required=False)
     ldap_server = forms.CharField(widget=forms.TextInput, required=False,
                                   help_text=('Include :port if not 389.'))
+
+    ldap_special = forms.CharField(widget=forms.TextInput, required=False,
+                                  help_text =('Optional seardh for uid lookup .'
+                                              '<br> fetch:attr=<list of LDAP attributes to fetch>:filter=<filterobject>+$email - $email means put email in as search value'))
+
     ldap_usercn = forms.CharField(widget=forms.TextInput, required=False,
                                   help_text=('Optional cn for user lookup.'
                                              '<br />E.g. "uid=" or "cn="'))

--- a/crits/core/management/commands/setconfig.py
+++ b/crits/core/management/commands/setconfig.py
@@ -78,6 +78,7 @@ class Command(BaseCommand):
            ldap_server:\t\t\t<string>
            ldap_usercn:\t\t\t<string>
            ldap_userdn:\t\t\t<string>
+           ldap_special:\t\t\t<string>
            ldap_update_on_login:\t<boolean> (ex: True, true, yes, or 1)
            log_directory:\t\t<full directory path>
            log_level:\t\t\t<INFO/DEBUG/WARN>

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -872,6 +872,7 @@ class CRITsAuthBackend(object):
             username = username.split("\\")[1]
         elif "@" in username:
             username = username.split("@")[0]
+
         user = CRITsUser.objects(username=username).first()
         if user:
             # If the user needs TOTP and it is not disabled system-wide, and
@@ -915,14 +916,63 @@ class CRITsAuthBackend(object):
                     l.set_option(ldap.OPT_REFERRALS, 0)
                     l.set_option(ldap.OPT_TIMEOUT, 10)
                     # setup auth for custom cn's
-                    if len(config.ldap_usercn) > 0:
-                        un = "%s%s,%s" % (config.ldap_usercn,
+
+
+                    #SAB New code
+                    if len(config.ldap_special) > 0:
+                        import re  # bring in the regular expression functions
+                        if "fetch" in config.ldap_special:
+                            rattr = []  # empty list of retrieve attributes
+                            sfilter=''  # empty search filter
+                            istring = config.ldap_special   # get the string
+                            pstr = istring.split(':')  # break the string into its tokens - separated by :
+                            for tken in pstr:
+                                if re.search('fetch',tken):
+                                    continue
+                                if re.search('attr',tken):   # process the attributes to be returned
+                                    tval = tken.split('=')  # split the token into value and assignments
+                                    # expect a comma separated list of attributes 
+                                    attlist = str(tval[1]).split(',')
+                                    for sattr in attlist:
+                                        rattr.append(sattr)
+                                elif re.search("filter",tken):  # is this a filter specification 
+                                    #SAB Improve to take a comma separated list of filters to build
+                                    # a more dynamic filter
+                                    tval = tken.split('=')  # split the token into value and assignments
+                                    flist = tval[1].split('+')
+                                    sfilter = flist[0]+"="
+                                    if re.search('\$email',flist[1]):
+                                        sfilter = sfilter+fusername
+                            
+                            scope = ldap.SCOPE_SUBTREE
+                            lresultid = l.search(config.ldap_userdn,scope,sfilter,rattr)
+                            if lresultid:
+                                rtype,rdata = l.result(lresultid,0)
+                                if rtype == ldap.RES_SEARCH_ENTRY:
+                                    (rdtag,r_data) = rdata[0] # since we want the DN for this particular user for login the first part of the tuple returned is 
+                                                              # the full DN for that user.
+                                    un = rdtag
+                                else:
+                                    un = fusername  # set to the username so that ldap login will fail
+                            else:
+                                un = fusername  # default, the LDAP login will die and local auth will take over.
+                        else:
+                            logger.info("SAB XXX did not match special")
+                            un = "%s%s,%s" % (config.ldap_usercn,
                                           fusername,
                                           config.ldap_userdn)
-                    elif "@" in config.ldap_userdn:
-                        un = "%s%s" % (fusername, config.ldap_userdn)
-                    else:
-                        un = fusername
+                    else :   # fall back into the original code
+                        # SAB original code - indented for new structure
+                        if len(config.ldap_usercn) > 0:
+                            un = "%s%s,%s" % (config.ldap_usercn,
+                                          fusername,
+                                          config.ldap_userdn)
+                        elif "@" in config.ldap_userdn:
+                            un = "%s%s" % (fusername, config.ldap_userdn)
+                        else:
+                            un = fusername
+                    # END SAB Mods
+
                     logger.info("Logging in user: %s" % un)
                     l.simple_bind_s(un, password)
                     user = self._successful_settings(user, e, totp_enabled)


### PR DESCRIPTION
Many LDAP implementations require looking up values in order to properly form the authentication bind.  This change allows for specifying a search string against the LDAP and a search used to pull the proper DN for a given user in these environments.  It also updates the command line management tooling to allow for specifying this new option via the manage.py command.
