### PR TITLE
Fix for source over addition

### DIFF
--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -125,7 +125,9 @@ class STIXParser():
                 try: # create CRITs Indicator from observable
                     item = observable.object_.properties
                     obj = Indicator.from_cybox(item, [self.source])
-                    obj.add_source(self.source)
+                    # SAB  the add source is redunadnt and causes the self.source object to grow
+                    # source is added by the Indicator.from_cybox call
+                    #obj.add_source(self.source)
                     obj.save(username=self.source_instance.analyst)
                     self.imported.append((Indicator._meta['crits_type'], obj))
                 except Exception, e: # probably caused by cybox object we don't handle


### PR DESCRIPTION
calling obj.add_source causes the self.source dictionary to increase exponentially.. This in turn affects each embedded document that is being added.  When there are more than a few indicators being added, this increase eventually causes the mongo engine to not be able to store the data in the database, and eventually hang.   This change works for both uploads from the UI and File type uploads from the API.
