### PR TITLE
Avoid error during upload of .msg file with attachment

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -1322,7 +1322,7 @@ def create_email_attachment(email, cleaned_data, analyst, source, method="Upload
         filename = filename.strip()
 
     # If selected, new sample inherits the campaigns of the related email.
-    if cleaned_data['inherit_campaigns']:
+    if cleaned_data.get('inherit_campaigns'):
         if campaign:
             email.campaign.append(EmbeddedCampaign(name=campaign, confidence=confidence, analyst=analyst))
         campaign = email.campaign


### PR DESCRIPTION
This fixes issues #197.
When creating a new Email TLO from a .msg file, the "create_email_attachment" is called with a contrived "cleaned_data" dictionary argument that does not contain an "inherit_campaigns" key. Since an attachment for a new .msg should not be inheriting Campaigns anyway, using "get" should be a good solution to this problem.
