### PR TITLE
Make API POST responses more useful.

### DIFF
--- a/crits/campaigns/api.py
+++ b/crits/campaigns/api.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
@@ -44,7 +45,7 @@ class CampaignResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the information to create the Campaign.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If a campaign name is not provided or creation fails.
 
         """
@@ -63,7 +64,16 @@ class CampaignResource(CRITsAPIResource):
                                 analyst,
                                 bucket_list,
                                 ticket)
+        content = {'return_code': 0,
+                   'type': 'Campaign',
+                   'message': result.get('message', ''),
+                   'id': result.get('id', '')}
+        if result.get('id'):
+            url = reverse('api_dispatch_detail',
+                          kwargs={'resource_name': 'campaigns',
+                                  'api_name': 'v1',
+                                  'pk': result.get('id')})
+            content['url'] = url
         if not result['success']:
-            raise BadRequest(result['message'])
-        else:
-            return bundle
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/campaigns/handlers.py
+++ b/crits/campaigns/handlers.py
@@ -300,7 +300,8 @@ def add_campaign(name, description, aliases, analyst, bucket_list=None,
     # Verify the Campaign does not exist.
     campaign = Campaign.objects(name=name).first()
     if campaign:
-        return {'success': False, 'message': ['Campaign already exists.']}
+        return {'success': False, 'message': ['Campaign already exists.'],
+                'id': str(campaign.id)}
 
     # Create new campaign.
     campaign = Campaign(name=name)
@@ -323,7 +324,10 @@ def add_campaign(name, description, aliases, analyst, bucket_list=None,
 
     try:
         campaign.save(username=analyst)
-        return {'success': True}
+        campaign.reload()
+        return {'success': True,
+                'message': 'Campaign created successfully!',
+                'id': str(campaign.id)}
     except ValidationError, e:
         return {'success':False, 'message': "Invalid value: %s" % e}
 

--- a/crits/certificates/handlers.py
+++ b/crits/certificates/handlers.py
@@ -318,6 +318,7 @@ def handle_cert_file(filename, data, source_name, user=None,
         'success':      True,
         'message':      'Uploaded certificate',
         'md5':          md5,
+        'id':           str(cert.id)
     }
 
     return status

--- a/crits/domains/api.py
+++ b/crits/domains/api.py
@@ -1,4 +1,5 @@
 from dateutil.parser import parse
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
@@ -42,11 +43,10 @@ class DomainResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the information to create the Domain.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If a domain name is not provided or creation fails.
         """
 
-        analyst = bundle.request.user.username
         request = bundle.request
         # Domain and source information
         domain = bundle.data.get('domain', None)
@@ -84,28 +84,36 @@ class DomainResource(CRITsAPIResource):
                 'bucket_list': bucket_list,
                 'ticket': ticket}
 
-        if analyst:
-            if not domain:
-                raise BadRequest('Need a Domain Name.')
-            # The empty list is necessary. The function requires a list of
-            # non-fatal errors so it can be added to if any other errors
-            # occur. Since we have none, we pass the empty list.
-            (result, errors, retVal) =  add_new_domain(data,
-                                                       request,
-                                                       [])
-            if errors:
-                if not 'message' in retVal:
-                    retVal['message'] = ""
-                elif not isinstance(retVal['message'], basestring):
-                    retVal['message'] = str(retVal['message'])
-                for e in errors:
-                    retVal['message'] += " %s " % str(e)
-                raise BadRequest(retVal['message'])
-            else:
-                return bundle
-        else:
-            raise BadRequest('You must be an authenticated user!')
+        if not domain:
+            raise BadRequest('Need a Domain Name.')
+        # The empty list is necessary. The function requires a list of
+        # non-fatal errors so it can be added to if any other errors
+        # occur. Since we have none, we pass the empty list.
+        (result, errors, retVal) =  add_new_domain(data,
+                                                    request,
+                                                    [])
+        if not 'message' in retVal:
+            retVal['message'] = ""
+        elif not isinstance(retVal['message'], basestring):
+            retVal['message'] = str(retVal['message'])
+        if errors:
+            for e in errors:
+                retVal['message'] += " %s " % str(e)
 
+        obj = retVal.get('object', None)
+        content = {'return_code': 0,
+                   'type': 'Domain',
+                   'message': retVal.get('message', '')}
+        if obj:
+            content['id'] = str(obj.id)
+            url = reverse('api_dispatch_detail',
+                          kwargs={'resource_name': 'domains',
+                                  'api_name': 'v1',
+                                  'pk': str(obj.id)})
+            content['url'] = url
+        if not result['success']:
+            content['return_code'] = 1
+        self.crits_response(content)
 
 class WhoIsResource(CRITsAPIResource):
     """
@@ -127,7 +135,7 @@ class WhoIsResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the information to create the Domain.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If a domain name is not provided or creation fails.
         """
 
@@ -149,7 +157,17 @@ class WhoIsResource(CRITsAPIResource):
             raise BadRequest('Cannot parse date: %s' % str(e))
 
         result = add_whois(domain, whois, date, analyst, True)
+
+        content = {'return_code': 0,
+                   'type': 'Domain',
+                   'message': result.get('message', ''),
+                   'id': result.get('id', '')}
+        if result.get('id'):
+            url = reverse('api_dispatch_detail',
+                          kwargs={'resource_name': 'domains',
+                                  'api_name': 'v1',
+                                  'pk': result.get('id')})
+            content['url'] = url
         if not result['success']:
-            raise BadRequest('Could not add whois: %s' % str(result['message']))
-        else:
-            return bundle
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/domains/handlers.py
+++ b/crits/domains/handlers.py
@@ -529,9 +529,9 @@ def add_whois(domain, data, date, analyst, editable):
     try:
         whois_entry = domain.add_whois(data, analyst, date, editable)
         domain.save(username=analyst)
-        return {"success": True, 'whois': whois_entry}
+        return {"success": True, 'whois': whois_entry, 'id': str(domain.id)}
     except ValidationError, e:
-        return {"success": False, "message": e}
+        return {"success": False, "message": e, 'id': str(domain.id)}
 
 def edit_whois(domain, data, date, analyst):
     """

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -27,6 +27,7 @@ from crits.config.config import CRITsConfig
 from crits.core.crits_mongoengine import json_handler, create_embedded_source
 from crits.core.crits_mongoengine import EmbeddedCampaign
 from crits.core.data_tools import clean_dict
+from crits.core.exceptions import ZipFileError
 from crits.core.handlers import class_from_id
 from crits.core.handlers import build_jtable, jtable_ajax_list, jtable_ajax_delete
 from crits.core.handlers import csv_export
@@ -39,7 +40,6 @@ from crits.indicators.handlers import handle_indicator_ind
 from crits.indicators.indicator import Indicator
 from crits.notifications.handlers import remove_user_from_notification
 from crits.samples.handlers import handle_file, handle_uploaded_file, mail_sample
-from crits.samples.sample import Sample
 
 def create_email_field_dict(field_name,
                             field_type,
@@ -514,6 +514,7 @@ def handle_email_fields(data, analyst, method):
 
     try:
         new_email.save(username=analyst)
+        new_email.reload()
         result['object'] = new_email
         result['status'] = True
     except Exception, e:
@@ -586,6 +587,7 @@ def handle_json(data, sourcename, reference, analyst, method,
 
     try:
         result['object'].save(username=analyst)
+        result['object'].reload()
     except Exception, e:
         result['reason'] = "Failed to save object.\n<br /><pre>%s</pre>" % str(e)
 
@@ -690,6 +692,7 @@ def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
 
         try:
             result['object'].save(username=analyst)
+            result['object'].reload()
         except Exception, e:
             result['reason'] = "Failed to save object.\n<br /><pre>%s</pre>" % str(e)
             return result

--- a/crits/events/handlers.py
+++ b/crits/events/handlers.py
@@ -22,7 +22,6 @@ from crits.core.user_tools import is_user_subscribed
 from crits.events.event import Event, EventType
 from crits.notifications.handlers import remove_user_from_notification
 from crits.samples.handlers import handle_uploaded_file, mail_sample
-from crits.samples.sample import Sample
 from crits.services.handlers import run_triage
 
 
@@ -300,7 +299,8 @@ def add_new_event(title, description, event_type, source, method, reference,
                                                   args=[event.id]),
                                           title))
         result = {'success': True,
-                  'message': message}
+                  'message': message,
+                  'id': str(event.id)}
     except ValidationError, e:
         result = {'success': False,
                   'message': e}

--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -585,7 +585,7 @@ def handle_indicator_insert(ind, source, reference='', analyst='', method='',
                 try:
                     validate_ipv46_address(domain_or_ip)
                     url_contains_ip = True
-                except DjangoValidationError, e:
+                except DjangoValidationError:
                     pass
             if not url_contains_ip:
                 success = None
@@ -597,7 +597,8 @@ def handle_indicator_insert(ind, source, reference='', analyst='', method='',
                         indicator_link = '<a href=\"%s\">View indicator</a>.</div>' \
                                          % (reverse('crits.indicators.views.indicator', args=[indicator.id]));
                         message = "Indicator was added, but an error occurred. " + indicator_link + "<br>"
-                        return {'success':False, 'message':message + success['message']}
+                        return {'success':False, 'message':message + success['message'],
+                                'id': str(indicator.id)}
 
                 if not success or not 'object' in success:
                     dmain = Domain.objects(domain=domain_or_ip).first()
@@ -629,7 +630,8 @@ def handle_indicator_insert(ind, source, reference='', analyst='', method='',
                     indicator_link = '<a href=\"%s\">View indicator</a>.</div>' \
                                      % (reverse('crits.indicators.views.indicator', args=[indicator.id]));
                     message = "Indicator was added, but an error occurred. " + indicator_link + "<br>"
-                    return {'success':False, 'message':message + success['message']}
+                    return {'success':False, 'message':message + success['message'],
+                            'id': str(indicator.id)}
 
             if not success or not 'object' in success:
                 ip = IP.objects(ip=indicator.value).first()
@@ -648,7 +650,7 @@ def handle_indicator_insert(ind, source, reference='', analyst='', method='',
         indicator.reload()
         run_triage(None, indicator, analyst)
 
-    return {'success': True, 'objectid': indicator.id,
+    return {'success': True, 'objectid': str(indicator.id),
             'is_new_indicator': is_new_indicator, 'object': indicator}
 
 def does_indicator_relationship_exist(field, indicator_relationships):
@@ -913,9 +915,11 @@ def activity_add(indicator_id, activity):
                                activity['description'],
                                activity['date'])
         indicator.save(username=activity['analyst'])
-        return {'success': True, 'object': activity}
+        return {'success': True, 'object': activity,
+                'id': str(indicator.id)}
     except ValidationError, e:
-        return {'success': False, 'message': e}
+        return {'success': False, 'message': e,
+                'id': str(indicator.id)}
 
 def activity_update(indicator_id, activity):
     """

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -1,5 +1,3 @@
-import datetime
-
 from hashlib import md5
 
 from django.conf import settings
@@ -12,7 +10,6 @@ from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.data_tools import convert_string_to_bool
 from crits.core.handlers import get_object_types
 from crits.core.handsontable_tools import form_to_dict, get_field_from_label
-from crits.core.crits_mongoengine import EmbeddedCampaign
 from crits.core.mongo_tools import put_file, mongo_connector
 from crits.core.user_tools import get_user_organization
 from crits.indicators.indicator import Indicator
@@ -379,6 +376,7 @@ def add_object(type_, oid, object_type, name, source, method,
         if (get_objects):
             results['objects'] = obj.sort_objects()
 
+        results['id'] = str(obj.id)
         return results
     except ValidationError, e:
         return {'success': False,
@@ -600,7 +598,7 @@ def create_indicator_from_object(rel_type, rel_id, ind_type, value,
         value = value.lower().strip()
         ind_type = ind_type.strip()
         source_name = source_name.strip()
-        
+
         create_indicator_result = {}
         ind_tlist = ind_type.split(" - ")
         if ind_tlist[0] == ind_tlist[1]:

--- a/crits/pcaps/handlers.py
+++ b/crits/pcaps/handlers.py
@@ -325,6 +325,7 @@ def handle_pcap_file(filename, data, source_name, user=None,
         'success':      True,
         'message':      'Uploaded pcap',
         'md5':          md5,
+        'id':           str(pcap.id),
     }
 
     return status

--- a/crits/relationships/api.py
+++ b/crits/relationships/api.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
@@ -44,7 +45,7 @@ class RelationshipResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the relationship information.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If necessary data is not provided or creation fails.
 
         """
@@ -70,7 +71,17 @@ class RelationshipResource(CRITsAPIResource):
                                     rel_date=rel_date,
                                     analyst=analyst,
                                     get_rels=False)
+
+        content = {'return_code': 0,
+                   'type': left_type,
+                   'message': result.get('message', ''),
+                   'id': left_id}
+        rname = self.resource_name_from_type(left_type)
+        url = reverse('api_dispatch_detail',
+                        kwargs={'resource_name': rname,
+                                'api_name': 'v1',
+                                'pk': left_id})
+        content['url'] = url
         if not result['success']:
-            raise BadRequest(result['message'])
-        else:
-            return bundle
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/samples/api.py
+++ b/crits/samples/api.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
@@ -42,7 +43,7 @@ class SampleResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the information to create the Sample.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If filedata is not provided or creation fails.
         """
 
@@ -96,9 +97,21 @@ class SampleResource(CRITsAPIResource):
                                           ticket=ticket,
                                           is_return_only_md5=False)
 
+        content = {'return_code': 0,
+                   'type': 'Sample'}
+        result = {'success': False}
+
         if len(sample_md5) > 0:
-            if not sample_md5[0].get('success') and 'message' in sample_md5[0]:
-                raise BadRequest(sample_md5[0]['message'])
-            return bundle
-        else:
-            raise BadRequest('Unable to create sample from data.')
+            result = sample_md5[0]
+            content['message'] = result.get('message', '')
+            content['id'] = str(result.get('object').id)
+            if content.get('id'):
+                url = reverse('api_dispatch_detail',
+                            kwargs={'resource_name': 'samples',
+                                    'api_name': 'v1',
+                                    'pk': content.get('id')})
+                content['url'] = url
+        if not result['success']:
+            content['return_code'] = 1
+            content['message'] = "Could not create Sample for unknown reason."
+        self.crits_response(content)

--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -1038,8 +1038,6 @@ def handle_file(filename, data, source, method='Generic', reference=None, relate
         if cached_results != None:
             cached_results[md5_digest] = sample
 
-    retVal['object'] = sample
-
     # attempt to discover binary in GridFS before assuming we don't
     # have it
     sample.discover_binary()
@@ -1169,6 +1167,7 @@ def handle_file(filename, data, source, method='Generic', reference=None, relate
     if is_return_only_md5 == True:
         return md5_digest
     else:
+        retVal['object'] = sample
         return retVal
 
 def handle_uploaded_file(f, source, method="", reference=None, file_format=None,
@@ -1332,7 +1331,7 @@ def add_new_sample_via_bulk(data, rowData, request, errors, is_validate_only=Fal
     #is_email_results = data.get('email')
     related_md5 = data.get('related_md5')
     source = data.get('source')
-    #method = data.get('method')
+    method = data.get('method', '')
     reference = data.get('reference')
     bucket_list = data.get(form_consts.Common.BUCKET_LIST_VARIABLE_NAME)
     ticket = data.get(form_consts.Common.TICKET_VARIABLE_NAME)

--- a/crits/services/api.py
+++ b/crits/services/api.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
@@ -44,7 +45,7 @@ class ServiceResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the service results to add.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If necessary data is not provided or creation fails.
 
         """
@@ -85,7 +86,17 @@ class ServiceResource(CRITsAPIResource):
             if not result['success']:
                 message += ", %s" % result['message']
                 success = False
+
+        content = {'return_code': 0,
+                   'type': object_type,
+                   'message': message,
+                   'id': object_id}
+        rname = self.resource_name_from_type(object_type)
+        url = reverse('api_dispatch_detail',
+                        kwargs={'resource_name': rname,
+                                'api_name': 'v1',
+                                'pk': object_id})
+        content['url'] = url
         if not success:
-            raise BadRequest(message)
-        else:
-            return bundle
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/targets/api.py
+++ b/crits/targets/api.py
@@ -1,6 +1,6 @@
+from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
-from tastypie.exceptions import BadRequest
 
 from crits.targets.target import Target
 from crits.targets.handlers import upsert_target
@@ -43,14 +43,24 @@ class TargetResource(CRITsAPIResource):
 
         :param bundle: Bundle containing the information to create the Target.
         :type bundle: Tastypie Bundle object.
-        :returns: Bundle object.
+        :returns: HttpResponse.
         :raises BadRequest: If creation fails.
         """
 
         analyst = bundle.request.user.username
         data = bundle.data
         result = upsert_target(data, analyst)
-        if result['success']:
-            return bundle
-        else:
-            raise BadRequest(result['message'])
+
+        content = {'return_code': 0,
+                   'type': 'Target',
+                   'message': result.get('message', ''),
+                   'id': result.get('id', '')}
+        if result.get('id'):
+            url = reverse('api_dispatch_detail',
+                          kwargs={'resource_name': 'targets',
+                                  'api_name': 'v1',
+                                  'pk': result.get('id')})
+            content['url'] = url
+        if not result['success']:
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/targets/handlers.py
+++ b/crits/targets/handlers.py
@@ -68,8 +68,10 @@ def upsert_target(data, analyst):
 
     try:
         target.save(username=analyst)
+        target.reload()
         return {'success': True,
-                'message': "Target saved successfully"}
+                'message': "Target saved successfully",
+                'id': str(target.id)}
     except ValidationError, e:
         return {'success': False,
                 'message': "Target save failed: %s" % e}

--- a/documentation/help_main.html
+++ b/documentation/help_main.html
@@ -461,25 +461,26 @@ phrase.</p>
 <li><a class="reference internal" href="#searching-using-get-parameters" id="id75">17.2&nbsp;&nbsp;&nbsp;Searching Using GET Parameters</a></li>
 <li><a class="reference internal" href="#limiting-get-request-results" id="id76">17.3&nbsp;&nbsp;&nbsp;Limiting GET Request Results</a></li>
 <li><a class="reference internal" href="#examples" id="id77">17.4&nbsp;&nbsp;&nbsp;Examples:</a></li>
-<li><a class="reference internal" href="#common-post-parameters" id="id78">17.5&nbsp;&nbsp;&nbsp;Common POST Parameters</a></li>
-<li><a class="reference internal" href="#campaign-api" id="id79">17.6&nbsp;&nbsp;&nbsp;Campaign API</a></li>
-<li><a class="reference internal" href="#certificate-api" id="id80">17.7&nbsp;&nbsp;&nbsp;Certificate API</a></li>
-<li><a class="reference internal" href="#domain-api" id="id81">17.8&nbsp;&nbsp;&nbsp;Domain API</a></li>
-<li><a class="reference internal" href="#email-api" id="id82">17.9&nbsp;&nbsp;&nbsp;Email API</a></li>
-<li><a class="reference internal" href="#event-api" id="id83">17.10&nbsp;&nbsp;&nbsp;Event API</a></li>
-<li><a class="reference internal" href="#indicator-api" id="id84">17.11&nbsp;&nbsp;&nbsp;Indicator API</a></li>
-<li><a class="reference internal" href="#indicator-activity-api" id="id85">17.12&nbsp;&nbsp;&nbsp;Indicator Activity API</a></li>
-<li><a class="reference internal" href="#ip-api" id="id86">17.13&nbsp;&nbsp;&nbsp;IP API</a></li>
-<li><a class="reference internal" href="#object-api" id="id87">17.14&nbsp;&nbsp;&nbsp;Object API</a></li>
-<li><a class="reference internal" href="#pcap-api" id="id88">17.15&nbsp;&nbsp;&nbsp;PCAP API</a></li>
-<li><a class="reference internal" href="#raw-data-api" id="id89">17.16&nbsp;&nbsp;&nbsp;Raw Data API</a></li>
-<li><a class="reference internal" href="#relationship-api" id="id90">17.17&nbsp;&nbsp;&nbsp;Relationship API</a></li>
-<li><a class="reference internal" href="#sample-api" id="id91">17.18&nbsp;&nbsp;&nbsp;Sample API</a></li>
-<li><a class="reference internal" href="#screenshot-api" id="id92">17.19&nbsp;&nbsp;&nbsp;Screenshot API</a></li>
-<li><a class="reference internal" href="#service-api" id="id93">17.20&nbsp;&nbsp;&nbsp;Service API</a></li>
-<li><a class="reference internal" href="#standards-api" id="id94">17.21&nbsp;&nbsp;&nbsp;Standards API</a></li>
-<li><a class="reference internal" href="#target-api" id="id95">17.22&nbsp;&nbsp;&nbsp;Target API</a></li>
-<li><a class="reference internal" href="#whois-api" id="id96">17.23&nbsp;&nbsp;&nbsp;WhoIs API</a></li>
+<li><a class="reference internal" href="#post-responses" id="id78">17.5&nbsp;&nbsp;&nbsp;POST Responses</a></li>
+<li><a class="reference internal" href="#common-post-parameters" id="id79">17.6&nbsp;&nbsp;&nbsp;Common POST Parameters</a></li>
+<li><a class="reference internal" href="#campaign-api" id="id80">17.7&nbsp;&nbsp;&nbsp;Campaign API</a></li>
+<li><a class="reference internal" href="#certificate-api" id="id81">17.8&nbsp;&nbsp;&nbsp;Certificate API</a></li>
+<li><a class="reference internal" href="#domain-api" id="id82">17.9&nbsp;&nbsp;&nbsp;Domain API</a></li>
+<li><a class="reference internal" href="#email-api" id="id83">17.10&nbsp;&nbsp;&nbsp;Email API</a></li>
+<li><a class="reference internal" href="#event-api" id="id84">17.11&nbsp;&nbsp;&nbsp;Event API</a></li>
+<li><a class="reference internal" href="#indicator-api" id="id85">17.12&nbsp;&nbsp;&nbsp;Indicator API</a></li>
+<li><a class="reference internal" href="#indicator-activity-api" id="id86">17.13&nbsp;&nbsp;&nbsp;Indicator Activity API</a></li>
+<li><a class="reference internal" href="#ip-api" id="id87">17.14&nbsp;&nbsp;&nbsp;IP API</a></li>
+<li><a class="reference internal" href="#object-api" id="id88">17.15&nbsp;&nbsp;&nbsp;Object API</a></li>
+<li><a class="reference internal" href="#pcap-api" id="id89">17.16&nbsp;&nbsp;&nbsp;PCAP API</a></li>
+<li><a class="reference internal" href="#raw-data-api" id="id90">17.17&nbsp;&nbsp;&nbsp;Raw Data API</a></li>
+<li><a class="reference internal" href="#relationship-api" id="id91">17.18&nbsp;&nbsp;&nbsp;Relationship API</a></li>
+<li><a class="reference internal" href="#sample-api" id="id92">17.19&nbsp;&nbsp;&nbsp;Sample API</a></li>
+<li><a class="reference internal" href="#screenshot-api" id="id93">17.20&nbsp;&nbsp;&nbsp;Screenshot API</a></li>
+<li><a class="reference internal" href="#service-api" id="id94">17.21&nbsp;&nbsp;&nbsp;Service API</a></li>
+<li><a class="reference internal" href="#standards-api" id="id95">17.22&nbsp;&nbsp;&nbsp;Standards API</a></li>
+<li><a class="reference internal" href="#target-api" id="id96">17.23&nbsp;&nbsp;&nbsp;Target API</a></li>
+<li><a class="reference internal" href="#whois-api" id="id97">17.24&nbsp;&nbsp;&nbsp;WhoIs API</a></li>
 </ul>
 </li>
 </ul>
@@ -2017,8 +2018,37 @@ curl -F &quot;<a class="reference external" href="mailto:filedata=&#64;/path/to/
 </dd>
 </dl>
 </div>
+<div class="section" id="post-responses">
+<h2><a class="toc-backref" href="#id78">17.5&nbsp;&nbsp;&nbsp;POST Responses</a></h2>
+<p>In most cases when submitting a POST to add new content to CRITs you will
+get a response in the following JSON format:</p>
+<blockquote>
+<div class="line-block">
+<div class="line">{</div>
+<div class="line-block">
+<div class="line">&quot;return_code&quot;: &lt;code&gt;,</div>
+<div class="line">&quot;type&quot;: &lt;type&gt;,</div>
+<div class="line">&quot;id&quot;: &lt;object_id&gt;,</div>
+<div class="line">&quot;message&quot;: &lt;message&gt;,</div>
+<div class="line">&quot;url&quot;: &lt;url&gt;</div>
+</div>
+<div class="line">}</div>
+</div>
+</blockquote>
+<p>The return_code is usually 0 for success, 1 for failure. Some API calls may
+wish to extend this to include other codes to represent other results. Those
+return codes should be listed in the appropriate sections below.</p>
+<p>In the event a new TLO was created or content was successfully added to an
+existing TLO, the TLO type and ID will be returned to you. In addition, a
+URL will be provided which can be used to query the API for the details of
+that TLO.</p>
+<p>If there is a message to give context, whether the request was successful or
+not, it will also be provided.</p>
+<p>In some situations the entire response may not look like this. Refer to the
+sections below for any special conditions you may need to look out for.</p>
+</div>
 <div class="section" id="common-post-parameters">
-<h2><a class="toc-backref" href="#id78">17.5&nbsp;&nbsp;&nbsp;Common POST Parameters</a></h2>
+<h2><a class="toc-backref" href="#id79">17.6&nbsp;&nbsp;&nbsp;Common POST Parameters</a></h2>
 <p>These parameters are frequently used across most top-level objects in CRITs.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -2060,7 +2090,7 @@ curl -F &quot;<a class="reference external" href="mailto:filedata=&#64;/path/to/
 </table>
 </div>
 <div class="section" id="campaign-api">
-<h2><a class="toc-backref" href="#id79">17.6&nbsp;&nbsp;&nbsp;Campaign API</a></h2>
+<h2><a class="toc-backref" href="#id80">17.7&nbsp;&nbsp;&nbsp;Campaign API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/campaigns/</p>
@@ -2084,7 +2114,7 @@ curl -F &quot;<a class="reference external" href="mailto:filedata=&#64;/path/to/
 </table>
 </div>
 <div class="section" id="certificate-api">
-<h2><a class="toc-backref" href="#id80">17.7&nbsp;&nbsp;&nbsp;Certificate API</a></h2>
+<h2><a class="toc-backref" href="#id81">17.8&nbsp;&nbsp;&nbsp;Certificate API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/certificates/</p>
@@ -2114,7 +2144,7 @@ curl -F &quot;<a class="reference external" href="mailto:filedata=&#64;/path/to/
 </table>
 </div>
 <div class="section" id="domain-api">
-<h2><a class="toc-backref" href="#id81">17.8&nbsp;&nbsp;&nbsp;Domain API</a></h2>
+<h2><a class="toc-backref" href="#id82">17.9&nbsp;&nbsp;&nbsp;Domain API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/domains/</p>
@@ -2148,7 +2178,7 @@ curl -F &quot;<a class="reference external" href="mailto:filedata=&#64;/path/to/
 </table>
 </div>
 <div class="section" id="email-api">
-<h2><a class="toc-backref" href="#id82">17.9&nbsp;&nbsp;&nbsp;Email API</a></h2>
+<h2><a class="toc-backref" href="#id83">17.10&nbsp;&nbsp;&nbsp;Email API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/emails/</p>
@@ -2213,7 +2243,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="event-api">
-<h2><a class="toc-backref" href="#id83">17.10&nbsp;&nbsp;&nbsp;Event API</a></h2>
+<h2><a class="toc-backref" href="#id84">17.11&nbsp;&nbsp;&nbsp;Event API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/events/</p>
@@ -2239,7 +2269,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="indicator-api">
-<h2><a class="toc-backref" href="#id84">17.11&nbsp;&nbsp;&nbsp;Indicator API</a></h2>
+<h2><a class="toc-backref" href="#id85">17.12&nbsp;&nbsp;&nbsp;Indicator API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/indicators/</p>
@@ -2290,7 +2320,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="indicator-activity-api">
-<h2><a class="toc-backref" href="#id85">17.12&nbsp;&nbsp;&nbsp;Indicator Activity API</a></h2>
+<h2><a class="toc-backref" href="#id86">17.13&nbsp;&nbsp;&nbsp;Indicator Activity API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/indicator_activity/</blockquote>
@@ -2311,7 +2341,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="ip-api">
-<h2><a class="toc-backref" href="#id86">17.13&nbsp;&nbsp;&nbsp;IP API</a></h2>
+<h2><a class="toc-backref" href="#id87">17.14&nbsp;&nbsp;&nbsp;IP API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/ips/</p>
@@ -2338,7 +2368,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="object-api">
-<h2><a class="toc-backref" href="#id87">17.14&nbsp;&nbsp;&nbsp;Object API</a></h2>
+<h2><a class="toc-backref" href="#id88">17.15&nbsp;&nbsp;&nbsp;Object API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/objects/</blockquote>
@@ -2369,7 +2399,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="pcap-api">
-<h2><a class="toc-backref" href="#id88">17.15&nbsp;&nbsp;&nbsp;PCAP API</a></h2>
+<h2><a class="toc-backref" href="#id89">17.16&nbsp;&nbsp;&nbsp;PCAP API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/pcaps/</p>
@@ -2397,7 +2427,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="raw-data-api">
-<h2><a class="toc-backref" href="#id89">17.16&nbsp;&nbsp;&nbsp;Raw Data API</a></h2>
+<h2><a class="toc-backref" href="#id90">17.17&nbsp;&nbsp;&nbsp;Raw Data API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/raw_data/</p>
@@ -2445,7 +2475,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="relationship-api">
-<h2><a class="toc-backref" href="#id90">17.17&nbsp;&nbsp;&nbsp;Relationship API</a></h2>
+<h2><a class="toc-backref" href="#id91">17.18&nbsp;&nbsp;&nbsp;Relationship API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/relationships/</blockquote>
@@ -2470,7 +2500,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="sample-api">
-<h2><a class="toc-backref" href="#id91">17.18&nbsp;&nbsp;&nbsp;Sample API</a></h2>
+<h2><a class="toc-backref" href="#id92">17.19&nbsp;&nbsp;&nbsp;Sample API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/samples/</p>
@@ -2515,7 +2545,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="screenshot-api">
-<h2><a class="toc-backref" href="#id92">17.19&nbsp;&nbsp;&nbsp;Screenshot API</a></h2>
+<h2><a class="toc-backref" href="#id93">17.20&nbsp;&nbsp;&nbsp;Screenshot API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/screenshots/</p>
@@ -2545,7 +2575,7 @@ only &quot;date&quot; is required:</p>
 </table>
 </div>
 <div class="section" id="service-api">
-<h2><a class="toc-backref" href="#id93">17.20&nbsp;&nbsp;&nbsp;Service API</a></h2>
+<h2><a class="toc-backref" href="#id94">17.21&nbsp;&nbsp;&nbsp;Service API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/services/</blockquote>
@@ -2590,7 +2620,7 @@ only &quot;date&quot; is required:</p>
 field, &quot;log_level&quot; will be set to &quot;info&quot; if it is not provided.</p>
 </div>
 <div class="section" id="standards-api">
-<h2><a class="toc-backref" href="#id94">17.21&nbsp;&nbsp;&nbsp;Standards API</a></h2>
+<h2><a class="toc-backref" href="#id95">17.22&nbsp;&nbsp;&nbsp;Standards API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/standards/</blockquote>
@@ -2609,9 +2639,16 @@ field, &quot;log_level&quot; will be set to &quot;info&quot; if it is not provid
 </tr>
 </tbody>
 </table>
+<p>POST Response:</p>
+<p>Since it is possible to import multiple TLOs within a single standards document
+the format of the response is different from most others. You will find two fields
+called &quot;imported&quot; and &quot;failed&quot;. The imported field is a list of dictionaries. Each
+dictionary contains the TLO type (type), ObjectId (id), and API details URL (url).
+The failed field is a list of dictionaries containing the TLO type (type) CRITs
+tried to create and a message (message) detailing what went wrong.</p>
 </div>
 <div class="section" id="target-api">
-<h2><a class="toc-backref" href="#id95">17.22&nbsp;&nbsp;&nbsp;Target API</a></h2>
+<h2><a class="toc-backref" href="#id96">17.23&nbsp;&nbsp;&nbsp;Target API</a></h2>
 <p>GET:</p>
 <blockquote>
 <p>/api/v1/targets/</p>
@@ -2646,7 +2683,7 @@ field, &quot;log_level&quot; will be set to &quot;info&quot; if it is not provid
 </table>
 </div>
 <div class="section" id="whois-api">
-<h2><a class="toc-backref" href="#id96">17.23&nbsp;&nbsp;&nbsp;WhoIs API</a></h2>
+<h2><a class="toc-backref" href="#id97">17.24&nbsp;&nbsp;&nbsp;WhoIs API</a></h2>
 <p>POST:</p>
 <blockquote>
 /api/v1/whois/</blockquote>

--- a/documentation/help_main.txt
+++ b/documentation/help_main.txt
@@ -1389,8 +1389,36 @@ Listing the Domains
         | result=JSON.load(res.body)
 
 
-      
-        
+POST Responses
+-------------------------------------------
+
+In most cases when submitting a POST to add new content to CRITs you will
+get a response in the following JSON format:
+
+        | {
+        |   "return_code": <code>,
+        |   "type": <type>,
+        |   "id": <object_id>,
+        |   "message": <message>,
+        |   "url": <url>
+        | }
+
+The return_code is usually 0 for success, 1 for failure. Some API calls may
+wish to extend this to include other codes to represent other results. Those
+return codes should be listed in the appropriate sections below.
+
+In the event a new TLO was created or content was successfully added to an
+existing TLO, the TLO type and ID will be returned to you. In addition, a
+URL will be provided which can be used to query the API for the details of
+that TLO.
+
+If there is a message to give context, whether the request was successful or
+not, it will also be provided.
+
+In some situations the entire response may not look like this. Refer to the
+sections below for any special conditions you may need to look out for.
+
+
 Common POST Parameters
 -------------------------------------------
 
@@ -1771,6 +1799,15 @@ Unique POST Parameters:
 :filedata: The STIX document if uploading as a file using the 'file' upload_type.
 :xml: The STIX document if uploading as 'xml' using the 'xml' upload_type.
 :make_event: Wether to create an event within CRITS.  False if not present.  Set to True
+
+POST Response:
+
+Since it is possible to import multiple TLOs within a single standards document
+the format of the response is different from most others. You will find two fields
+called "imported" and "failed". The imported field is a list of dictionaries. Each
+dictionary contains the TLO type (type), ObjectId (id), and API details URL (url).
+The failed field is a list of dictionaries containing the TLO type (type) CRITs
+tried to create and a message (message) detailing what went wrong.
 
 
 Target API


### PR DESCRIPTION
Include useful information like the TLO type, ObjectId, Details URL, and
a return code. Documentation included in the Help on the "standard"
response format, return codes, and situations where the format differs.

This required updating several handlers to include (in some way) getting
the ObjectId from the created TLO. Also fixed a couple bugs along the
way (orphaned imports, variables, etc.).
