### PR TITLE
Sample api related type

### DIFF
--- a/crits/samples/api.py
+++ b/crits/samples/api.py
@@ -103,6 +103,8 @@ class SampleResource(CRITsAPIResource):
 
         if len(sample_md5) > 0:
             result = sample_md5[0]
+            if result.get('success') is False:
+                raise BadRequest('Must provide a related type ')
             content['message'] = result.get('message', '')
             content['id'] = str(result.get('object').id)
             if content.get('id'):


### PR DESCRIPTION
If no related_type is passed in, None is used.  When related_type is None, then handle_file fails to process and causes a python exception because the id field in the returned data is not set.
