### PR TITLE
Fixing source addition to objects created from STIX.

### DIFF
--- a/crits/certificates/certificate.py
+++ b/crits/certificates/certificate.py
@@ -151,15 +151,13 @@ class Certificate(CritsBaseAttributes, CritsSourceDocument, Document):
         return ([obs], self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
-        Convert a Cybox DefinedObject to a MongoEngine Indicator object.
+        Convert a Cybox DefinedObject to a MongoEngine Certificate object.
 
-        :param cybox_obs: The cybox object to create the indicator from.
+        :param cybox_obs: The cybox object to create the Certificate from.
         :type cybox_obs: :class:`cybox.core.Observable``
-        :param source: The source list for the Indicator.
-        :type source: list
-        :returns: :class:`crits.indicators.indicator.Indicator`
+        :returns: :class:`crits.certificates.certificate.Certificate`
         """
         cybox_object = cybox_obs.object_.properties
         if cybox_object.md5:
@@ -167,7 +165,7 @@ class Certificate(CritsBaseAttributes, CritsSourceDocument, Document):
             if db_obj:
                 return db_obj
 
-        cert = cls(source=source)
+        cert = cls()
         cert.md5 = cybox_object.md5
         cert.filename = cybox_object.file_name
         cert.filetype = cybox_object.file_format
@@ -177,4 +175,3 @@ class Certificate(CritsBaseAttributes, CritsSourceDocument, Document):
             if isinstance(obj.properties, Artifact):
                 cert.add_file_data(base64.b64decode(obj.properties.data))
         return cert
-

--- a/crits/domains/domain.py
+++ b/crits/domains/domain.py
@@ -207,23 +207,20 @@ class Domain(CritsBaseAttributes, CritsSourceDocument, Document):
         return ([Observable(obj)], self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
-        Convert a Cybox DefinedObject to a MongoEngine Indicator object.
+        Convert a Cybox DefinedObject to a MongoEngine Domain object.
 
-        :param cybox_obs: The cybox observable to create the indicator from.
+        :param cybox_obs: The cybox observable to create the Domain from.
         :type cybox_obs: :class:`cybox.core.Observable``
-        :param source: The source list for the Indicator.
-        :type source: list
-        :returns: :class:`crits.indicators.indicator.Indicator`
+        :returns: :class:`crits.domains.domain.Domain`
         """
         cybox_object = cybox_obs.object_.properties
         db_obj = Domain.objects(domain=str(cybox_object.value)).first()
         if db_obj:
             return db_obj
         else:
-            domain = cls(source=source)
+            domain = cls()
             domain.domain = str(cybox_object.value)
             domain.record_type = str(cybox_object.type_)
             return domain
-

--- a/crits/emails/email.py
+++ b/crits/emails/email.py
@@ -216,13 +216,17 @@ class Email(CritsBaseAttributes, CritsSourceDocument, Document):
         return (observables, self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
         Convert a Cybox DefinedObject to a MongoEngine Email object.
+
+        :param cybox_obs: The cybox object to create the Email from.
+        :type cybox_obs: :class:`cybox.core.Observable``
+        :returns: :class:`crits.emails.email.Email`
         """
 
         cybox_obj = cybox_obs.object_.properties
-        email = cls(source=source)
+        email = cls()
 
         if cybox_obj.header:
             email.from_address = str(cybox_obj.header.from_)
@@ -239,4 +243,3 @@ class Email(CritsBaseAttributes, CritsSourceDocument, Document):
             email.raw_header = str(cybox_obj.raw_header)
 
         return email
-

--- a/crits/events/event.py
+++ b/crits/events/event.py
@@ -90,14 +90,12 @@ class Event(CritsBaseAttributes, CritsSourceDocument, Document):
         return self.title
 
     @classmethod
-    def from_stix(cls, stix_package, source):
+    def from_stix(cls, stix_package):
         """
         Converts a stix_package to a CRITs Event.
 
         :param stix_package: A stix package.
         :type stix_package: :class:`stix.core.STIXPackage`
-        :param source: The source list for this STIX package.
-        :type source: list
         :returns: None, :class:`crits.events.event.Event'
         """
 
@@ -107,7 +105,7 @@ class Event(CritsBaseAttributes, CritsSourceDocument, Document):
         if isinstance(stix_package, STIXPackage):
             stix_header = stix_package.stix_header
             stix_id = stix_package.id_
-            event = cls(source=source)
+            event = cls()
             event.title = "STIX Document %s" % stix_id
             event.event_type = "Collective Threat Intelligence"
             event.description = str(datetime.datetime.now())

--- a/crits/indicators/indicator.py
+++ b/crits/indicators/indicator.py
@@ -212,14 +212,12 @@ class Indicator(CritsBaseAttributes, CritsSourceDocument, Document):
         return (observables, self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_object, source):
+    def from_cybox(cls, cybox_object):
         """
         Convert a Cybox DefinedObject to a MongoEngine Indicator object.
 
         :param cybox_object: The cybox object to create the indicator from.
         :type cybox_object: :class:`cybox.core.Observable``
-        :param source: The source list for the Indicator.
-        :type source: list
         :returns: :class:`crits.indicators.indicator.Indicator`
         """
 
@@ -233,7 +231,7 @@ class Indicator(CritsBaseAttributes, CritsSourceDocument, Document):
         if db_indicator:
             indicator = db_indicator
         else:
-            indicator = cls(source=source)
+            indicator = cls()
             indicator.value = obj.value
             indicator.created = obj.date
             indicator.modified = obj.date

--- a/crits/ips/ip.py
+++ b/crits/ips/ip.py
@@ -90,14 +90,12 @@ class IP(CritsBaseAttributes, CritsSourceDocument, Document):
         return ([Observable(obj)], self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
         Convert a Cybox Address to a CRITs IP object.
 
         :param cybox_obs: The cybox object to create the IP from.
         :type cybox_obs: :class:`cybox.core.Observable`
-        :param source: The source list for the IP.
-        :type source: list
         :returns: :class:`crits.ips.ip.IP`
         """
         cybox_object = cybox_obs.object_.properties
@@ -107,7 +105,7 @@ class IP(CritsBaseAttributes, CritsSourceDocument, Document):
         if db_obj:
             return db_obj
 
-        ip = cls(source=source)
+        ip = cls()
         ip.ip = str(cybox_object.address_value)
         ip.ip_type = iptype
         return ip

--- a/crits/pcaps/pcap.py
+++ b/crits/pcaps/pcap.py
@@ -144,14 +144,12 @@ class PCAP(CritsBaseAttributes, CritsSourceDocument, Document):
         return ([obs], self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
         Convert a Cybox Artifact to a CRITs PCAP object.
 
         :param cybox_obs: The cybox object to create the PCAP from.
         :type cybox_obs: :class:`cybox.core.Observable`
-        :param source: The source list for the PCAP.
-        :type source: list
         :returns: :class:`crits.pcaps.pcap.PCAP`
         """
         cybox_object = cybox_obs.object_.properties
@@ -159,7 +157,7 @@ class PCAP(CritsBaseAttributes, CritsSourceDocument, Document):
             db_obj = PCAP.objects(md5=cybox_object.md5).first()
             if db_obj:
                 return db_obj
-        pcap = cls(source=source)
+        pcap = cls()
         pcap.description = str(cybox_obs.description)
         pcap.md5 = cybox_object.md5
         pcap.filename = str(cybox_object.file_name)

--- a/crits/raw_data/raw_data.py
+++ b/crits/raw_data/raw_data.py
@@ -254,21 +254,18 @@ class RawData(CritsBaseAttributes, CritsSourceDocument, Document):
         return ([obs], self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
-        Convert a Cybox DefinedObject to a MongoEngine Indicator object.
+        Convert a Cybox DefinedObject to a MongoEngine RawData object.
 
-        :param cybox_obs: The cybox object to create the indicator from.
+        :param cybox_obs: The cybox object to create the RawData from.
         :type cybox_obs: :class:`cybox.core.Observable``
-        :param source: The source list for the Indicator.
-        :type source: list
-        :returns: :class:`crits.indicators.indicator.Indicator`
+        :returns: :class:`crits.raw_data.raw_data.RawData`
         """
         cybox_object = cybox_obs.object_.properties
-        rawdata = cls(source=source)
+        rawdata = cls()
         rawdata.add_file_data(cybox_object.data)
         db_obj = RawData.objects(md5=rawdata.md5).first()
         if db_obj:
             return db_obj
         return rawdata
-

--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -186,17 +186,22 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, Document):
         return (observables, self.releasability)
 
     @classmethod
-    def from_cybox(cls, cybox_obs, source):
+    def from_cybox(cls, cybox_obs):
         """
-            Convert a Cybox DefinedObject to a MongoEngine Sample object.
+        Convert a Cybox DefinedObject to a MongoEngine Sample object.
+
+        :param cybox_obs: The cybox object to create the Sample from.
+        :type cybox_obs: :class:`cybox.core.Observable``
+        :returns: :class:`crits.samples.sample.Sample`
         """
+
         cybox_object = cybox_obs.object_.properties
         if cybox_object.md5:
             db_obj = Sample.objects(md5=cybox_object.md5).first()
             if db_obj: # if a sample with md5 already exists
                 return db_obj # don't modify, just return
 
-        sample = cls(source=source) # else, start creating new sample record
+        sample = cls() # else, start creating new sample record
         sample.filename = str(cybox_object.file_name)
         sample.size = cybox_object.size_in_bytes.value if cybox_object.size_in_bytes else 0
         for hash_ in cybox_object.hashes:

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -100,8 +100,9 @@ class STIXParser():
         self.source.instances.append(self.source_instance)
 
         if make_event:
-            event = Event.from_stix(stix_package=self.package, source=[self.source])
+            event = Event.from_stix(stix_package=self.package)
             try:
+                event.add_source(self.source)
                 event.save(username=self.source_instance.analyst)
                 self.imported.append((Event._meta['crits_type'], event))
             except Exception, e:
@@ -124,7 +125,7 @@ class STIXParser():
             for observable in indicator.observables: # get each observable from indicator (expecting only 1)
                 try: # create CRITs Indicator from observable
                     item = observable.object_.properties
-                    obj = Indicator.from_cybox(item, [self.source])
+                    obj = Indicator.from_cybox(item)
                     obj.add_source(self.source)
                     obj.save(username=self.source_instance.analyst)
                     self.imported.append((Indicator._meta['crits_type'], obj))
@@ -145,7 +146,7 @@ class STIXParser():
             try: # try to create CRITs object from observable
                 item = obs.object_.properties
                 cls = self.get_crits_type(item) # determine which CRITs class matches
-                obj = cls.from_cybox(obs, [self.source])
+                obj = cls.from_cybox(obs)
                 obj.add_source(self.source)
                 obj.save(username=self.source_instance.analyst)
                 self.imported.append((cls._meta['crits_type'], obj)) # use class to parse object


### PR DESCRIPTION
When the objects are created using their `from_*()` function for cybox
or stix they will no longer come with the source being added. The STIX
Parser now handles adding the source after the object has been returned.

Also fixed some copy/paste issues with docstrings.
