### PR TITLE
Added configuration option customer cert bundle for LDAPs signed with in...

### DIFF
--- a/crits/config/config.py
+++ b/crits/config/config.py
@@ -41,6 +41,7 @@ class CRITsConfig(CritsDocument, Document):
     invalid_login_attempts = IntField(default=3)
     language_code = StringField(default='en-us')
     ldap_auth = BooleanField(default=False)
+    ldap_cert_bundle = StringField(default='')
     ldap_tls = BooleanField(default=False)
     ldap_server = StringField(default='')
     ldap_usercn = StringField(default='')

--- a/crits/config/forms.py
+++ b/crits/config/forms.py
@@ -82,6 +82,8 @@ class ConfigLDAPForm(forms.Form):
     required_css_class = 'required'
     ldap_auth = forms.BooleanField(initial=False,
                                    required=False)
+    ldap_cert_bundle = forms.CharField(widget=forms.TextInput, required=False,
+                                       help_text='Path to custom cert bundle.')
     ldap_tls = forms.BooleanField(initial=False,
                                   required=False)
     ldap_server = forms.CharField(widget=forms.TextInput, required=False,

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -783,6 +783,8 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
             return resp
         ldap_server = config.ldap_server.split(':')
         scheme = "ldap"
+        if config.ldap_cert_bundle:
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, config.ldap_cert_bundle)
         if config.ldap_tls:
             scheme = "ldaps"
         url = ldapurl.LDAPUrl('%s://%s' % (scheme, ldap_server[0]))
@@ -901,6 +903,9 @@ class CRITsAuthBackend(object):
                     # don't parse the port if there is one
                     ldap_server = config.ldap_server.split(':')
                     scheme = "ldap"
+                    if config.ldap_cert_bundle:
+                        ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, 
+                                        config.ldap_cert_bundle)
                     if config.ldap_tls:
                         scheme = "ldaps"
                     url = ldapurl.LDAPUrl('%s://%s' % (scheme, ldap_server[0]))

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -178,6 +178,7 @@ INSTANCE_URL =           crits_config.get('instance_url', '')
 INVALID_LOGIN_ATTEMPTS = crits_config.get('invalid_login_attempts', 3) - 1
 LANGUAGE_CODE =          crits_config.get('language_code', 'en-us')
 LDAP_AUTH =              crits_config.get('ldap_auth', False)
+LDAP_CERT_BUNDLE =       crits_config.get('ldap_cert_bundle', '')
 LDAP_SERVER =            crits_config.get('ldap_server', '')
 LDAP_USERDN =            crits_config.get('ldap_userdn', '')
 LDAP_USERCN =            crits_config.get('ldap_usercn', '')


### PR DESCRIPTION
...ternal certificate. This option allows python to trust an internally signed LDAP certificate for LDAPs.
