### PR TITLE
Services Thread/Process Pools

### DIFF
--- a/crits/config/config.py
+++ b/crits/config/config.py
@@ -59,6 +59,7 @@ class CRITsConfig(CritsDocument, Document):
     secure_cookie = BooleanField(default=True)
     service_dirs = ListField(StringField())
     service_model = StringField(default='process')
+    service_pool_size = IntField(default=50)
     session_timeout = IntField(default=12)
     splunk_search_url = StringField(default='')
     temp_dir = StringField(default='/tmp')

--- a/crits/config/forms.py
+++ b/crits/config/forms.py
@@ -162,6 +162,11 @@ class ConfigServicesForm(forms.Form):
                                       required=True,
                                       initial='process',
                                       help_text='*Requires a web server restart.')
+    service_pool_size = forms.IntegerField(required=False,
+                                           min_value=1,
+                                           initial="12",
+                                           help_text='Service Thread/Process Pool Size *Requires a web server restart.')
+
     def __init__(self, *args, **kwargs):
         super(ConfigServicesForm, self).__init__(*args, **kwargs)       
         

--- a/crits/core/management/commands/setconfig.py
+++ b/crits/core/management/commands/setconfig.py
@@ -92,6 +92,7 @@ class Command(BaseCommand):
            secure_cookie:\t\t<boolean> (ex: True, true, yes, or 1)
            service_dirs:\t\t<list of full directory paths>
            service_model:\t\t<process/thread/local>
+           service_pool_size:\t\t<integer>
            session_timeout:\t\t<integer>
            splunk_search_url:\t\t<string>
            temp_dir:\t\t\t<full directory path>
@@ -220,7 +221,7 @@ def set_config_attribute(crits_config, attr, value):
             else:
                 raise CE('%s is a boolean True/False.' % attr)
         if attr in ('depth_max', 'invalid_login_attempts', 'rel_max',
-                    'session_timeout', 'total_max'):
+                    'service_pool_size', 'session_timeout', 'total_max'):
             try:
                 value = int(value)
             except:

--- a/crits/services/core.py
+++ b/crits/services/core.py
@@ -1,14 +1,12 @@
 from datetime import datetime
 from distutils.version import StrictVersion
-import hashlib
+
 from importlib import import_module
+
 import logging
 import os.path
 import shutil
-import sys
 import tempfile
-from multiprocessing import Process
-from threading import Thread
 import uuid
 
 from django.conf import settings

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -209,6 +209,7 @@ RT_URL =                 crits_config.get('rt_url', None)
 SECURE_COOKIE =          crits_config.get('secure_cookie', True)
 SERVICE_DIRS =           tuple(crits_config.get('service_dirs', []))
 SERVICE_MODEL =          crits_config.get('service_model', SERVICE_MODEL)
+SERVICE_POOL_SIZE =      int(crits_config.get('service_pool_size', 50))
 SESSION_TIMEOUT =        int(crits_config.get('session_timeout', 12)) * 60 * 60
 SPLUNK_SEARCH_URL =      crits_config.get('splunk_search_url', None)
 TEMP_DIR =               crits_config.get('temp_dir', '/tmp')


### PR DESCRIPTION
Related to issue #209 

Adding process and thread pools for service processing. There is now a new field in the control panel/services panel with a configuration parameter to specify the maximum size of the pools.

I am pushing this up to the distributed_services branch because I have only tested this on the distributed_services branch. I am sure this would also work on master but I didn't want to deal with the merge conflicts. Note that the apply_sync() method puts tasks on a Queue, so work threads/processes should pull the tasks off the queue in the order they were put in but not necessarily complete processing them in the same order.
