### PR TITLE
Allow for returning a single STIX document.

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -322,12 +322,12 @@ class CRITsSerializer(Serializer):
                                            bin_fmt,
                                            object_types,
                                            objects,
-                                           sources)
+                                           sources,
+                                           False)
         except Exception:
             data = ""
         if 'data' in data:
             data = data['data']
-        print "Data: ", data
         return data
 
     def _convert_mongoengine(self, data, options=None):


### PR DESCRIPTION
Changes allows code to use the download object handler to return a
single STIX document instead of a zip of multiple STIX documents.
Default behavior is still a zip of multiple STIX documents.

Issue with this comes when there's an Event or multiple events. Since
each Event is its own unique STIX document, you can't have more than one
Event in the STIX doc. Also, this code doesn't analyze all of the
objects it needs to convert to find an Event to base the document off
of. Since the primary (currently only) use of this is through the API this
is ok for now. If people want to get multiple Events out of the system
they should use another format, and for each one grab the STIX version
of it.

Closes #229. 
