### PR TITLE
Fix the filename in API sample uploads

### DIFF
--- a/crits/samples/api.py
+++ b/crits/samples/api.py
@@ -59,7 +59,6 @@ class SampleResource(CRITsAPIResource):
             content['message'] = 'Not a valid upload type.'
             self.crits_response(content)
         if type_ == 'metadata':
-            filename = bundle.data.get('filename', None)
             md5 = bundle.data.get('md5', None)
             password = None
             filedata = None
@@ -71,8 +70,8 @@ class SampleResource(CRITsAPIResource):
                 content['message'] = "Upload type of 'file' but no file uploaded."
                 self.crits_response(content)
             filedata = file_
-            filename = None
 
+        filename = bundle.data.get('filename', None)
         campaign = bundle.data.get('campaign', None)
         confidence = bundle.data.get('confidence', None)
         source = bundle.data.get('source', None)


### PR DESCRIPTION
Am I missing something or the filename of all the samples uploaded through API is supposed to be "filedata"? Of course metadata uploads had the proper filename attribute. Thanks!
