### PR TITLE
sector.js and tag-it.js loading issue

### DIFF
--- a/crits/core/templates/base.html
+++ b/crits/core/templates/base.html
@@ -45,6 +45,7 @@
 
     <script type="text/javascript" src="/js/chardinjs.min.js"></script>
     <script src="/js/jtable/jquery.jtable.top-paging.min.js" type="text/javascript"></script>
+    <script src="/js/tag-it.js" type="text/javascript" charset="utf-8"></script>
 
     {% if nav_template %}
         {% include nav_template %}

--- a/crits/core/templates/bucket_list_widget.html
+++ b/crits/core/templates/bucket_list_widget.html
@@ -1,6 +1,5 @@
 {% load url from future %}
 
-<script src="/js/tag-it.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
     var loading = true;
     $(document).ready(function() {


### PR DESCRIPTION
Fixing an issue where tag-it.js has not been loaded and will cause javascript issues. This occurs in sectors.js

It's an ordering issue and this was never seen before because most of the time the bucket widget is loaded along with the sector widget.

However if the bucket widget is not loaded but the sector widget is, then there will be a javascript error since tag-it will not exist.

Test by creating a new email, and in the "To" field specify a Target email that doesn't exist. Go to the email's detail page and click on the "To" link. The new Target page will not render due to JS errors.
