### PR TITLE
Open Ticket URLs in a new tab

### DIFF
--- a/crits/core/templates/tickets_row_widget.html
+++ b/crits/core/templates/tickets_row_widget.html
@@ -1,12 +1,13 @@
 {% load url from future %}
+{% load filters %}
 
 <tr>
     <td data-field="ticket_number">{{ticket.ticket_number}}</td>
     <td data-field="url">
       {% if "http://" in ticket.ticket_number or "https://" in ticket.ticket_number %}
-        {{ ticket.ticket_number|urlize }}
+        {{ ticket.ticket_number|urlize|url_target_blank }}
       {% else %}
-        {{ crits_config.rt_url|add:ticket.ticket_number | urlize }}
+        {{ crits_config.rt_url|add:ticket.ticket_number | urlize|url_target_blank }}
       {% endif %}
     </td>
     <td data-field="date">{{ticket.date}}</td>

--- a/crits/core/templatetags/filters.py
+++ b/crits/core/templatetags/filters.py
@@ -1,9 +1,12 @@
 import cgi
+import re
 import string
 
 from crits.indicators.handlers import does_indicator_relationship_exist
 
 from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.safestring import mark_safe
 register = template.Library()
 
 # TODO: make this more generic if it winds up being used more
@@ -171,4 +174,10 @@ def absVal(value):
     :returns: int
     """
     return abs(value)
+
+@register.filter
+@stringfilter
+def url_target_blank(var):
+    """Follow the 'urlize' filter with this to make the URL open in a new tab."""
+    return mark_safe(re.sub("<a([^>]+)(?<!target=)>",'<a target="_blank"\\1>',var))
     


### PR DESCRIPTION
If the user clicks on a Ticket URL, it takes them away from CRITs. It would be better if the link opened the destination in a new tab.
