### PR TITLE
Append force_full=1 to pivot links.

### DIFF
--- a/crits/services/templates/services_results_default.html
+++ b/crits/services/templates/services_results_default.html
@@ -24,7 +24,7 @@
         <tr>
             <td>
                 {% if result.result %}
-                <a href="{% url 'crits.core.views.global_search_listing' %}?search_type=global&q={{result.result|urlencode}}">{{result.result}}</a>
+                <a href="{% url 'crits.core.views.global_search_listing' %}?search_type=global&q={{result.result|urlencode}}&force_full=1">{{result.result}}</a>
                 {% endif %}
             </td>
             {% for key, value in result.items %}


### PR DESCRIPTION
If you have a service result which is "foo (bar)" the parenthesis are
taken as part of the regex, and the pivot is broken. The 'detectexact'
notion was killed off in d240572d01482b4f6dd0b92f45c1310abb334479, which
is what I think is the root cause of this.
