### PR TITLE
Actors Removing Last List Item Bug

### DIFF
--- a/crits/actors/actor.py
+++ b/crits/actors/actor.py
@@ -304,7 +304,7 @@ class Actor(CritsBaseAttributes, CritsSourceDocument, Document):
             self.aliases = aliases
         else:
             existing_aliases = self.aliases
-        if existing_aliases:
+        if existing_aliases is not None:
             for a in aliases:
                 if a not in existing_aliases:
                     existing_aliases.append(a)


### PR DESCRIPTION
Fixing Actors bug where if you have an empty aliases, add two aliases, and then delete both aliases, refresh the page and the last item to be deleted will not be deleted. The database shows a list of [last_item, '']. The empty string should not be in the list. This commit fixes the empty string. This same bug might exist in other areas?
