### PR TITLE
Newly Assigned Campaign Modification Bug

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -1217,8 +1217,7 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
         """
 
         if isinstance(campaign_item, EmbeddedCampaign):
-            self.remove_campaign(campaign_name=campaign_name,
-                                 campaign_date=campaign_item.date)
+            self.remove_campaign(campaign_name=campaign_item.name)
             self.add_campaign(campaign_item=campaign_item)
 
     def add_bucket_list(self, tags, analyst, append=True):


### PR DESCRIPTION
Fixes issue #281 https://github.com/crits/crits/issues/281 Newly Assigned Campaign Modification Bug

Closes #281

Probably better to remove a campaign based on its name rather than the date.
