### PR TITLE
Sample Filenames Aliases Can't Be Deleted.

### DIFF
--- a/crits/samples/templates/samples_detail.html
+++ b/crits/samples/templates/samples_detail.html
@@ -14,6 +14,7 @@
     var get_xor = "{% url 'crits.samples.views.xor' sample.md5 %}?key=";
     var update_sample_filename = "{% url 'crits.samples.views.set_sample_filename' %}";
     var update_sample_filenames = "{% url 'crits.samples.views.set_sample_filenames' %}";
+    var is_admin = "{{ admin }}";
 </script>
 
 {% if sample %}


### PR DESCRIPTION
Fixing an issue with a missing variable needed in the samples javascript that was preventing deletion of the filenames aliases.
