### PR TITLE
Add "is_admin" JS var to enable Sample filename deletion

### DIFF
--- a/crits/samples/templates/samples_detail.html
+++ b/crits/samples/templates/samples_detail.html
@@ -14,6 +14,7 @@
     var get_xor = "{% url 'crits.samples.views.xor' sample.md5 %}?key=";
     var update_sample_filename = "{% url 'crits.samples.views.set_sample_filename' %}";
     var update_sample_filenames = "{% url 'crits.samples.views.set_sample_filenames' %}";
+    var is_admin = "{{ admin }}";
 </script>
 
 {% if sample %}


### PR DESCRIPTION
It seems that the "is_admin" Javascript variable was left out, which was preventing the user from removing a filename from a Sample.
