### PR TITLE
Add 'ushlex' to the salt requirements for python, per 2014-10-30 change ...

### DIFF
--- a/salt/roots/salt/python_requirements.sls
+++ b/salt/roots/salt/python_requirements.sls
@@ -102,3 +102,9 @@ celery:
     - name: celery==3.0.12
     - requires:
       - cmd: python-pip
+
+ushlex:
+  pip.installed:
+    - name: ushlex==0.99
+    - requires:
+      - cmd: python-pip


### PR DESCRIPTION
In UPDATING, dsnellgrove made a comment that ushlex is now a prereq. This adds it to salt, so that the vagrant config chases that modification.
