### PR TITLE
API delete support for domains and IPs

### DIFF
--- a/crits/campaigns/api.py
+++ b/crits/campaigns/api.py
@@ -12,8 +12,6 @@ from crits.indicators.indicator import Indicator
 from crits.ips.ip import IP
 from crits.pcaps.pcap import PCAP
 from crits.samples.sample import Sample
-from crits.raw_data.raw_data import RawData
-from crits.actors.actor import Actor
 
 from crits.campaigns.handlers import add_campaign, campaign_remove, remove_campaign
 from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
@@ -76,12 +74,12 @@ class CampaignResource(CRITsAPIResource):
             content['message'] = 'Need a Campaign name.'
             self.crits_response(content)
 
-        result = add_campaign(name,
-                              description,
-                              aliases,
-                              analyst,
-                              bucket_list,
-                              ticket)
+        result =  add_campaign(name,
+                               description,
+                               aliases,
+                               analyst,
+                               bucket_list,
+                               ticket)
         if result.get('id'):
             url = reverse('api_dispatch_detail',
                           kwargs={'resource_name': 'campaigns',
@@ -186,7 +184,6 @@ class CampaignResource(CRITsAPIResource):
         """
         This will delete a specific campaign ID record.
         It will also delete all the campaign references in the TLOs.
-        This will override the delete_detail in the core API.
 
         The campaign ID must be part of the URL (/api/v1/campaigns/{id}/)
 
@@ -212,11 +209,10 @@ class CampaignResource(CRITsAPIResource):
 
         campaign = Campaign.objects(id=id).first()
         sources = user_sources(analyst)
- 
+
         # Remove associations
         formatted_query = {'campaign.name': campaign.name}
-        for obj_type in [Domain, PCAP, Indicator, Email, Sample, IP, Event, RawData, Actor]:
-           
+        for obj_type in [Sample, PCAP, Indicator, Email, Domain, IP, Event]:
           objects = obj_type.objects(source__name__in=sources, __raw__=formatted_query)
           for obj in objects:
             result = campaign_remove(obj._meta['crits_type'],obj.id,campaign.name,analyst)

--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -12,11 +12,10 @@ from tastypie.authentication import SessionAuthentication, ApiKeyAuthentication
 from tastypie.utils.mime import build_content_type
 from tastypie_mongoengine.resources import MongoEngineResource
 
-from crits.core.class_mapper import class_from_path_name
 from crits.core.data_tools import format_file, create_zip
-from crits.core.handlers import download_object_handler, remove_quotes, generate_regex, delete_id
+from crits.core.handlers import download_object_handler, remove_quotes, generate_regex
 from crits.core.source_access import SourceAccess
-from crits.core.user_tools import user_sources, is_admin
+from crits.core.user_tools import user_sources
 
 
 # The following leverages code from the Tastypie library.
@@ -637,6 +636,7 @@ class CRITsAPIResource(MongoEngineResource):
 
         raise NotImplementedError('You cannot currently update this object through the API.')
 
+
     def obj_delete_list(self, bundle, **kwargs):
         """
         Delete list of objects in CRITs. Should be overridden by each
@@ -646,6 +646,7 @@ class CRITsAPIResource(MongoEngineResource):
         """
 
         raise NotImplementedError('You cannot currently delete objects through the API.')
+
 
     def obj_delete(self, bundle, **kwargs):
         """
@@ -660,46 +661,13 @@ class CRITsAPIResource(MongoEngineResource):
 
     def delete_detail(self, bundle, **kwargs):
         """
-        Delete a top-level object in CRITs. 
-        If special actions are needed for a TLO, it will be overriden in the objects API.
+        Delete an object in CRITs. Should be overridden by each
+        individual top-level resource.
 
-	The URL for the request should be /api/v1/{object}/{id}/
-
-        :returns: HttpResponse
+        :returns: NotImplementedError if the resource doesn't override.
         """
 
-        content = {'return_code': 1,
-                   'type': 'Core'}
-
-        analyst = bundle.user.username
-        if not is_admin(analyst):
-          content['message'] = 'You must be an admin to perform a delete.'
-          self.crits_response(content)
-
-        path = bundle.path
-        parts = path.split("/")
-        id = parts[(len(parts) - 2)]
-        path_type = parts[(len(parts) - 3)]
-
-        if not ObjectId.is_valid(id):
-          content['message'] = 'You must provide a valid CRITs ID.'
-          self.crits_response(content)
-
-        obj_type = class_from_path_name(path_type)
-        if obj_type == None:
-          content['message'] = 'The path contains an invalid type.'
-          self.crits_response(content)
-
-        content['type'] = obj_type._meta['crits_type']
-
-        result, message = delete_id(analyst,obj_type,id)
-
-        if result:
-          content['return_code'] = 0
-        else:
-          content['message'] = message
-
-        self.crits_response(content)
+        raise NotImplementedError('You cannot currently delete this object through the API.')
 
 
     def patch_detail(self, bundle, **kwargs):

--- a/crits/core/class_mapper.py
+++ b/crits/core/class_mapper.py
@@ -1,22 +1,5 @@
 from bson.objectid import ObjectId
 
-
-__obj_type_to_key_descriptor__ = {
-    'Actor': 'name',
-    'Campaign': 'name',
-    'Certificate': 'md5',
-    'Comment': 'object_id',
-    'Domain': 'domain',
-    'Email': 'id',
-    'Event': 'id',
-    'Indicator': 'id',
-    'IP': 'ip',
-    'PCAP': 'md5',
-    'RawData': 'title',
-    'Sample': 'md5',
-    'Target': 'email_address',
-}
-
 def class_from_id(type_, _id):
     """
     Return an instantiated class object.
@@ -122,9 +105,6 @@ def class_from_id(type_, _id):
         return UserRole.objects(id=_id).first()
     else:
         return None
-
-def key_descriptor_from_obj_type(obj_type):
-    return __obj_type_to_key_descriptor__.get(obj_type)
 
 def class_from_value(type_, value):
     """
@@ -298,67 +278,3 @@ def class_from_type(type_):
         return UserRole
     else:
         return None
-
-
-def class_from_path_name(path):
-    """
-    Return an class object based on the path name from the URL.
-
-    :param type_: The CRITs top-level object type.
-    :type type_: str
-    :param value: The value to search for.
-    :type value: str
-    :returns: class which inherits from
-              :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
-    """
-
-    # doing this to avoid circular imports
-    from crits.actors.actor import Actor
-    from crits.campaigns.campaign import Campaign
-    from crits.certificates.certificate import Certificate
-    from crits.comments.comment import Comment
-    from crits.domains.domain import Domain
-    from crits.emails.email import Email
-    from crits.events.event import Event
-    from crits.indicators.indicator import Indicator
-    from crits.ips.ip import IP
-    from crits.pcaps.pcap import PCAP
-    from crits.raw_data.raw_data import RawData
-    from crits.samples.sample import Sample
-    from crits.screenshots.screenshot import Screenshot
-    from crits.targets.target import Target
-
-    # Make sure value is a string...
-    value = str(path)
-
-    if path == 'ips':
-      return IP
-    elif path == 'domains':
-      return Domain
-    elif path == 'samples':
-      return Sample
-    elif path == 'campaigns':
-      return Campaign
-    elif path == 'pcaps':
-      return PCAP
-    elif path == 'emails':
-      return Email
-    elif path == 'comments':
-      return Comment
-    elif path == 'actors':
-      return Actor
-    elif path == 'certificates':
-      return Certificate
-    elif path == 'events':
-      return Event
-    elif path == 'raw_data':
-      return RawData
-    elif path == 'screenshots':
-      return Screenshot
-    elif path == 'targets':
-      return Target
-    elif path == 'indicators':
-      return Indicator
-    else:
-      return None
-

--- a/crits/domains/api.py
+++ b/crits/domains/api.py
@@ -7,9 +7,9 @@ from mongoengine.base import ValidationError
 from bson.objectid import ObjectId
 
 from crits.domains.domain import Domain
-from crits.domains.handlers import add_new_domain
+from crits.domains.handlers import add_new_domain, add_whois
 
-from crits.core.handlers import source_remove_all
+from crits.core.handlers import source_remove_all, delete_id
 from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
 from crits.core.api import CRITsSerializer, CRITsAPIResource
 from crits.core.user_tools import is_admin, user_sources
@@ -65,7 +65,6 @@ class DomainResource(CRITsAPIResource):
         # Also add IP information
         add_ip = bundle.data.get('add_ip', None)
         ip = bundle.data.get('ip', None)
-        ip_type = bundle.data.get('ip_type', None)
         same_source = bundle.data.get('same_source', None)
         ip_source = bundle.data.get('ip_source', None)
         ip_method = bundle.data.get('ip_method', None)
@@ -87,7 +86,6 @@ class DomainResource(CRITsAPIResource):
                 'ip_reference': ip_reference,
                 'add_ip': add_ip,
                 'ip': ip,
-                'ip_type': ip_type,
                 'add_indicators': add_indicators,
                 'bucket_list': bucket_list,
                 'ticket': ticket}
@@ -127,6 +125,44 @@ class DomainResource(CRITsAPIResource):
 
         self.crits_response(content)
 
+
+    def delete_detail(self, request, **kwargs):
+        """
+        This will delete a specific domain ID record.
+
+        The domain ID must be part of the URL (/api/v1/domains/{id}/)
+
+        :param request: The incoming request.
+        :type request: :class:`django.http.HttpRequest`
+        :returns: HttpResponse.
+        """
+        content = {'return_code': 1,
+                   'type': 'Domain'}
+
+        analyst = request.user.username
+        if not is_admin(analyst):
+          content['message'] = 'You must be an admin to delete domains.'
+          self.crits_response(content)
+
+        path = request.path
+        parts = path.split("/")
+        id = parts[(len(parts) - 2)]
+
+        if not ObjectId.is_valid(id):
+          content['message'] = 'You must provide a valid domain ID.'
+          self.crits_response(content)
+
+        obj_type = Domain
+
+        result, message = delete_id(analyst,obj_type,id)
+        
+        if result: 
+          content['return_code'] = 0
+        else:
+          content['message'] = message
+
+        self.crits_response(content)
+   
 
     def patch_detail(self, request, **kwargs):
         """
@@ -208,3 +244,61 @@ class DomainResource(CRITsAPIResource):
 
         self.crits_response(content)
 
+
+
+class WhoIsResource(CRITsAPIResource):
+    """
+    Domain Whois API Resource Class.
+    """
+
+    class Meta:
+        object_class = Domain
+        allowed_methods = ('post',)
+        resource_name = "whois"
+        authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
+                                             CRITsSessionAuthentication())
+        authorization = authorization.Authorization()
+        serializer = CRITsSerializer()
+
+    def obj_create(self, bundle, **kwargs):
+        """
+        Handles adding WhoIs entries to domains through the API.
+
+        :param bundle: Bundle containing the information to create the Domain.
+        :type bundle: Tastypie Bundle object.
+        :returns: HttpResponse.
+        :raises BadRequest: If a domain name is not provided or creation fails.
+        """
+
+        analyst = bundle.request.user.username
+        domain = bundle.data.get('domain', None)
+        date = bundle.data.get('date', None)
+        whois = bundle.data.get('whois', None)
+
+        if not domain:
+            raise BadRequest('Need a Domain Name.')
+        if not date:
+            raise BadRequest('Need a date for this entry.')
+        if not whois:
+            raise BadRequest('Need whois data.')
+
+        try:
+            date = parse(date, fuzzy=True)
+        except Exception, e:
+            raise BadRequest('Cannot parse date: %s' % str(e))
+
+        result = add_whois(domain, whois, date, analyst, True)
+
+        content = {'return_code': 0,
+                   'type': 'Domain',
+                   'message': result.get('message', ''),
+                   'id': result.get('id', '')}
+        if result.get('id'):
+            url = reverse('api_dispatch_detail',
+                          kwargs={'resource_name': 'domains',
+                                  'api_name': 'v1',
+                                  'pk': result.get('id')})
+            content['url'] = url
+        if not result['success']:
+            content['return_code'] = 1
+        self.crits_response(content)

--- a/crits/ips/api.py
+++ b/crits/ips/api.py
@@ -7,7 +7,7 @@ from bson.objectid import ObjectId
 
 from crits.ips.ip import IP
 from crits.ips.handlers import ip_add_update
-from crits.core.handlers import source_remove_all
+from crits.core.handlers import source_remove_all, delete_id
 from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
 from crits.core.api import CRITsSerializer, CRITsAPIResource
 from crits.core.user_tools import is_admin, user_sources
@@ -98,6 +98,45 @@ class IPResource(CRITsAPIResource):
             content['url'] = url
         if result['success']:
             content['return_code'] = 0
+        self.crits_response(content)
+
+
+    def delete_detail(self, request, **kwargs):
+        """
+        This will delete a specific IP record. 
+
+        The IP ID must be part of the URL (/api/v1/ips/{id}/)
+
+        :param request: The incoming request.
+        :type request: :class:`django.http.HttpRequest`
+        :returns: HttpResponse.
+        """
+        content = {'return_code': 1,
+                   'type': 'IP'}
+
+        analyst = request.user.username
+
+        if not is_admin(analyst):
+          content['message'] = 'You must be an admin to delete IPs.'
+          self.crits_response(content)
+
+        path = request.path
+        parts = path.split("/")
+        id = parts[(len(parts) - 2)]
+
+        if not ObjectId.is_valid(id):
+          content['message'] = 'You must provide a valid IP ID.'
+          self.crits_response(content)
+
+        obj_type = IP
+
+        result, message = delete_id(analyst,obj_type,id)
+
+        if result:
+          content['return_code'] = 0
+        else:
+          content['message'] = message
+
         self.crits_response(content)
 
 


### PR DESCRIPTION
This is a rough draft of code that will enable delete support for the IP and domain APIs. Since an IP or domain can be associated with multiple sources and campaigns, this approach allows you to delete an individual reference or to delete the entire record. If you provide a campaign and source along with the record ID, then this will just delete the references to that campaign and source. If you only provide the record ID, then it will delete the entire record.

The code for delete support in the domain API is a little complicated. The django-tastypie-mongoengine won't accept a DELETE request with parameters passed in the body of the request. Therefore, the DELETE request must pass the parameters in the URL. However, in order to pass the request to the generate_domain_jtable, the request must be converted into a POST format. Since I didn't know the jtable code well enough to reformat it, I got around the issue by creating a fake POST object and passing that instead. This isn't the most elegant solution but it allowed me to contain the changes to the API code.

Being able to delete an IP or API reference would be useful for people who want to use CRITs to track only the current list of threats. For instance, IPs are sometimes removed from IOC lists because the compromised host has been fixed. These changes would allow you to remove the IP from the current list of threats via the API. This code still requires the user to have admin privileges in order to perform the deletion.

Please take a look at the code and let me know your thoughts. 
