### PR TITLE
Change field_type of "originating_ip" to "Address - ipv4-addr"

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -290,7 +290,7 @@ def get_email_detail(email_id, analyst):
                 ))
         email_fields.append(create_email_field_dict(
                 "originating_ip",
-                "String",
+                "Address - ipv4-addr",
                 email.originating_ip,
                 "Originating IP",
                 True, True, True, False, True,


### PR DESCRIPTION
If one clicks the plus button next to the "Originating IP" field in an email, an "Address - ipv4-addr" indicator is created and related, as you would expect. However, the code looks for a String relationship when determining if the plus button should have a circle around it or not. I'm guessing this was a copy/paste error. Changing the field_type of "originating_ip" from "String" to "Address - ipv4-addr" so that the created/related Indicator is recognized.