### PR TITLE
The strings tool should give paths, and should not print whitespace

### DIFF
--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -345,7 +345,7 @@ def make_ascii_strings(md5=None, data=None):
     strings_data = 'ASCII Strings\n'
     strings_data += "-" * 30
     strings_data += "\n"
-    ascii_regex = re.compile('([%s]{4,})' % string.printable)
+    ascii_regex = re.compile('([ -~]{4,})')
     matches = ascii_regex.findall(data)
     strings_data += '\n'.join([x for x in matches])
     return strings_data + "\n\n\n\n"


### PR DESCRIPTION
The strings.printable gives output that is not suitable for direct entry to a regex.
"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c" breaks:
- at the dash, which is interpreted (correctly) as the range from , to .
- at the closing bracket ], because it is not escaped.
- the rest of the line is ignored
I believe we don't really want all whitespace in a string.  It was my assumption that the 'strings' view would greatly resemble a default run of "strings" on a unix command-line.  This change gets closer to that idea.

Assuming the file includes a string like "C:\\path\to\directory\file", the current master would give:
- path
- directory
- file
And this change would result in "C:\\path\to\directory\file"