### PR TITLE
Better debugging when debug mode is not turned on.

### DIFF
--- a/crits/core/errors.py
+++ b/crits/core/errors.py
@@ -1,0 +1,17 @@
+import logging
+import sys
+import traceback
+
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+logger = logging.getLogger(__name__)
+
+def custom_500(request):
+    exception, value, tb = sys.exc_info()
+    ftb = traceback.format_exception(exception, value, tb)
+    logger.debug(ftb)
+    return render_to_response("500.html",
+                              {"exception": exception,
+                               "value": value},
+                                RequestContext(request))

--- a/crits/core/templates/500.html
+++ b/crits/core/templates/500.html
@@ -3,5 +3,16 @@
 {% block content %}
 <h1>Internal Server Error</h1>
 
-You have encountered a bug! Please report the circumstances to the application administrator
+You have encountered a bug! Please report the circumstances to the application administrator.
+<br />
+<br />
+<table>
+    <tr>
+        <td><b>Exception:</b></td><td>{{exception}}</td>
+    </tr>
+    <tr>
+        <td><b>Value:</b></td><td>{{value}}</td>
+    </tr>
+</table>
+
 {% endblock %}

--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -93,6 +93,7 @@ from crits.targets.forms import TargetInfoForm
 
 logger = logging.getLogger(__name__)
 
+
 @user_passes_test(user_can_view_data)
 def toggle_favorite(request):
     """

--- a/crits/dashboards/views.py
+++ b/crits/dashboards/views.py
@@ -1,17 +1,33 @@
+import json
+
 from django.contrib.auth.decorators import user_passes_test
-from crits.core.crits_mongoengine import json_handler
-from crits.core.user_tools import user_can_view_data
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-from crits.core.handlers import generate_global_search, generate_dashboard
-from crits.core.views import dashboard
-from django.http import HttpResponse
-from crits.dashboards.dashboard import SavedSearch, Dashboard
-from crits.dashboards.handlers import toggleTableVisibility,get_saved_searches_list,get_dashboard, getHREFLink, get_obj_type_from_string, clear_dashboard, save_data, get_table_data, generate_search_for_saved_table, delete_table, getRecordsForDefaultDashboardTable
-from crits.dashboards.handlers import switch_existing_search_to_dashboard, add_existing_search_to_dashboard, renameDashboard,changeTheme, deleteDashboard,getDashboardsForUser,createNewDashboard, setDefaultDashboard, cloneDashboard, setPublic, updateChildren
-import json
-import re
-from django.core.urlresolvers import reverse
+
+from crits.core.user_tools import user_can_view_data
+from crits.core.handlers import generate_global_search
+from crits.dashboards.dashboard import Dashboard
+from crits.dashboards.handlers import (toggleTableVisibility,
+                                       get_saved_searches_list,get_dashboard,
+                                       clear_dashboard,
+                                       save_data,
+                                       get_table_data,
+                                       generate_search_for_saved_table,
+                                       delete_table,
+                                       getRecordsForDefaultDashboardTable)
+from crits.dashboards.handlers import (switch_existing_search_to_dashboard,
+                                       add_existing_search_to_dashboard,
+                                       renameDashboard,
+                                       changeTheme,
+                                       deleteDashboard,
+                                       getDashboardsForUser,
+                                       createNewDashboard,
+                                       setDefaultDashboard,
+                                       cloneDashboard,
+                                       setPublic,
+                                       updateChildren)
 
 @user_passes_test(user_can_view_data)
 def saved_searches_list(request):
@@ -52,9 +68,9 @@ def edit_save_search(request, id):
     args = generate_search_for_saved_table(user=request.user, id=id, request=request)
     if 'Result' in args and args['Result'] == "ERROR":
         return respondWithError(args['Message'], request=request)
-    
+
     args['dashboards'] = getDashboardsForUser(request.user)
-    
+
     return render("save_search.html", args, request)
 
 @user_passes_test(user_can_view_data)
@@ -67,7 +83,7 @@ def delete_save_search(request):
         return respondWithError("Saved search cannot be found."\
                                 " Please refresh and try again", True)
     response = delete_table(request.user.id, id)
-    
+
     return httpResponse(response)
 
 @user_passes_test(user_can_view_data)
@@ -175,9 +191,9 @@ def save_new_dashboard(request):
         if 'sortDirection' in table and 'sortField' in table:
             sortBy = {'field':table['sortField'],'direction':table['sortDirection']}
         response = save_data(userId, table['columns'], table['tableName'],
-                             tableId=table['id'], isDefaultOnDashboard=isDefault, 
+                             tableId=table['id'], isDefaultOnDashboard=isDefault,
                              sortBy=sortBy, dashboard=dashboard,
-                             clone=clone, row=table['row'], grid_col=table['col'], 
+                             clone=clone, row=table['row'], grid_col=table['col'],
                              sizex=table['sizex'], sizey=table['sizey'])
         if not response['success']:
             return httpResponse(response)
@@ -249,7 +265,7 @@ def set_dashboard_public(request):
     if type(response) == str:
         return respondWithError(response, True)
     return respondWithSuccess(successMsg)
-    
+
 def ignore_parent(request, id):
     """
     Ajax call to ignore that the parent of the dashboard has been changed.
@@ -273,9 +289,9 @@ def delete_dashboard(request):
     except Exception as e:
         print e
         return respondWithError("An error occured while deleting dashboard. Please try again later.", True)
-        
+
     return respondWithSuccess(response+" deleted successfully.")
-    
+
 def rename_dashboard(request):
     """
     Ajax call to rename the dashboard. Called from saved_searches_list.html
@@ -297,7 +313,6 @@ def change_theme(request):
     """
     theme = request.GET.get('newTheme', None)
     id = request.GET.get('id', None)
-    message = ""
     if not id or not theme:
         return respondWithError("An error occured while changing theme. Please try again later. ", True)
     response = changeTheme(id, theme)
@@ -339,8 +354,8 @@ def respondWithError(message, isAjax=False, request=None):
         return HttpResponse(json.dumps({'success': False, 'message': message}),
                                     mimetype="application/json")
     return render("error.html", {"error": message}, request)
-    
-def respondWithSuccess(message): 
+
+def respondWithSuccess(message):
     """
     ajax response with success message
     """
@@ -355,6 +370,6 @@ def render(html, args, request):
 
 def httpResponse(response):
     """
-    Returns response for ajax calls. 
+    Returns response for ajax calls.
     """
     return HttpResponse(json.dumps(response), mimetype="application/json")

--- a/crits/urls.py
+++ b/crits/urls.py
@@ -4,7 +4,6 @@ import os
 from django.conf import settings
 from django.conf.urls import include, patterns
 
-
 urlpatterns = patterns('',
 
     (r'^', include('crits.core.urls')),                        # Core
@@ -29,6 +28,9 @@ urlpatterns = patterns('',
     (r'^standards/', include('crits.standards.urls')),         # Standards
     (r'^targets/', include('crits.targets.urls')),             # Targets
 )
+
+# Error overrides
+handler500 = 'crits.core.errors.custom_500'
 
 # Enable the API if configured
 if settings.ENABLE_API:


### PR DESCRIPTION
This change exposes the Exception name and the Value in the custom
500.html template. Created an "errors.py" file which contains the
custom_500 function to facilitate populating the template. This function
also formats the traceback and write it to the "crits.log" file as
DEBUG. This will allow people to disable DEBUG mode, but set logging to
DEBUG. Now the UI will be nice and clean, users will have a small bit of
information which they can relay to an admin who can find the
corresponding information in the log.