### PR TITLE
Notification fixes

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -4,6 +4,15 @@ references to changes in other repositories. Updates are sorted by commit date
 descending.
 
 Author: wxs
+Date:   2015-01-17
+
+    Notifications had an incorrect index set on them, causing them not to
+    expire after 30 days. This can be fixed by executing the following command
+    from a mongo shell:
+
+    db.notifications.ensureIndex({"date": 1}, {expireAfterSeconds: 2592000, background: true})
+
+Author: wxs
 Date:   2014-12-30
 
     The WHOIS feature for Domain objects has been removed from core and put

--- a/crits/comments/comment.py
+++ b/crits/comments/comment.py
@@ -7,6 +7,7 @@ from mongoengine import ObjectIdField, StringField, ListField, EmbeddedDocumentF
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
+from crits.core.user import CRITsUser
 from crits.core.fields import CritsDateTimeField
 from crits.core.crits_mongoengine import CritsDocument, CritsSchemaDocument
 from crits.core.crits_mongoengine import CritsDocumentFormatter, CritsSourceDocument
@@ -195,7 +196,7 @@ def parse_comment(comment):
     # get users
     for i in re_user.finditer(comment):
         user = i.group(0).replace('@','').strip()
-        if len(user):
+        if len(user) and CRITsUser.objects(username=user).count() == 1:
             users.append(user)
     # dedupe
     users = list(set(users))

--- a/crits/core/management/commands/create_indexes.py
+++ b/crits/core/management/commands/create_indexes.py
@@ -133,8 +133,9 @@ def create_indexes():
                                unique=True)
 
     notifications = mongo_connector(settings.COL_NOTIFICATIONS)
+    notifications.ensure_index("obj_id", background=True)
     # auto-expire notifications after 30 days
-    notifications.ensure_index("obj_id", background=True,
+    notifications.ensure_index("date", background=True,
                                expireAfterSeconds=2592000)
     notifications.ensure_index("users", background=True)
 


### PR DESCRIPTION
Fix some problems with notifications.

Indexes were not created correctly (see UPDATING) so that documents would be deleted after 30 days.

When commenting on an object don't parse usernames if they do not exist in the system.