### PR TITLE
Fixed bug for missing password w/ldap

### DIFF
--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -907,6 +907,10 @@ class CRITsAuthBackend(object):
         :returns: :class:`crits.core.user.CRITsUser`, None
         """
 
+        # Need username and password for logins, checkem both
+        if not all([username, password]):
+            return None
+
         e = EmbeddedLoginAttempt()
         e.user_agent = user_agent
         e.remote_addr = remote_addr


### PR DESCRIPTION
When using LDAP auth with Active Directory, if a valid user is passed with no password, situations exist where AD will let a user bind with no password (anonymous bind) and success login is processed. Force a non-blank username and password.