### PR TITLE
Stop duplicate MD5s created during bulk MD5 upload

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -1142,6 +1142,9 @@ def handle_file(filename, data, source, method='Generic', reference=None, relate
                                   % (reverse('crits.samples.views.detail',
                                              args=[sample.md5.lower()]),
                                              sample.md5.lower()))
+            # Update Cache
+            if cached_results != None:
+                cached_results[sample.md5] = sample
     else:
         # Duplicate sample, but uploaded anyways
         if is_validate_only == False:


### PR DESCRIPTION
If the same new MD5 is entered more than once in the Bulk Upload MD5 Samples table, and the table is uploaded, multiple Sample documents are created in the DB with the same MD5. These duplicate Samples cannot be accessed through the UI and must be manually merged/removed. This problem is caused by the caching optimization; the new Sample that was just added is not in the cache, so the code creates a duplicate Sample thinking that MD5 does not yet exist.

Fixed by updating the cache when a new Sample is added.