### PR TITLE
Modify query so Comments appear on Recent Activity page

### DIFF
--- a/crits/comments/handlers.py
+++ b/crits/comments/handlers.py
@@ -67,9 +67,9 @@ def get_aggregate_comments(atype, value, username, date=None):
     results = None
     if date:
         end_date = date+datetime.timedelta(days=1)
-        query = {'type': 'comment', 'date':{'$gte':date, '$lte':end_date}}
+        query = {'date':{'$gte':date, '$lte':end_date}}
     else:
-        query = {'type': 'comment'}
+        query = {}
     if atype == 'bytag':
         query['tags'] = value
     elif atype == 'byuser':


### PR DESCRIPTION
Comments were not appearing in the Recent Activity (Aggregate Comments) page.
Back in May 2014, notifications were moved out of the Comments collection of the DB, which eliminated the need for the 'type' field. From that point forward, adding a new Comment would not include a 'type' field, but the "get_aggregate_comments" function still queried for data using `{'type': 'comment'}`.

Modifying the query fixes this problem.