### PR TITLE
Fix filedata.seek(0) attempts against Domains and IPs

### DIFF
--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -187,8 +187,9 @@ def run_service(name, crits_type, identifier, analyst, obj=None,
     # Give the service a chance to check for required fields.
     try:
         service_class.valid_for(local_obj.obj)
-        # Reset back to the start so the service gets the full file.
-        local_obj.obj.filedata.seek(0)
+        if crits_type not in ('Domain','IP'):
+            # Reset back to the start so the service gets the full file.
+            local_obj.obj.filedata.seek(0)
     except ServiceConfigError as e:
         result['html'] = str(e)
         return result

--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -187,7 +187,7 @@ def run_service(name, crits_type, identifier, analyst, obj=None,
     # Give the service a chance to check for required fields.
     try:
         service_class.valid_for(local_obj.obj)
-        if local_obj.obj.filedata not None:
+        if local_obj.obj.filedata:
             # Reset back to the start so the service gets the full file.
             local_obj.obj.filedata.seek(0)
     except ServiceConfigError as e:

--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -187,7 +187,7 @@ def run_service(name, crits_type, identifier, analyst, obj=None,
     # Give the service a chance to check for required fields.
     try:
         service_class.valid_for(local_obj.obj)
-        if crits_type not in ('Domain','IP'):
+        if local_obj.obj.filedata not None:
             # Reset back to the start so the service gets the full file.
             local_obj.obj.filedata.seek(0)
     except ServiceConfigError as e:

--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -187,7 +187,7 @@ def run_service(name, crits_type, identifier, analyst, obj=None,
     # Give the service a chance to check for required fields.
     try:
         service_class.valid_for(local_obj.obj)
-        if local_obj.obj.filedata:
+        if hasattr(local_obj.obj, 'filedata'):
             # Reset back to the start so the service gets the full file.
             local_obj.obj.filedata.seek(0)
     except ServiceConfigError as e:


### PR DESCRIPTION
VirusTotal lookups against Domains and IP wouldn't run because somebody wanted to reset the filepointer on objects that don't have filedata attribute...


DEBUG 2015-02-06 17:09:16,312 crits.core.errors ['Traceback (most recent call last):\n', '  File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response\n    response = wrapped_callback(request, *callback_args, **callback_kwargs)\n', '  File "/usr/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view\n    return view_func(request, *args, **kwargs)\n', '  File "/data/crits/crits/services/views.py", line 189, in get_form\n    return service_run(request, name, crits_type, identifier)\n', '  File "/usr/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view\n    return view_func(request, *args, **kwargs)\n', '  File "/data/crits/crits/services/views.py", line 258, in service_run\n    custom_config=custom_config)\n', '  File "/data/crits/crits/services/handlers.py", line 191, in run_service\n    local_obj.obj.filedata.seek(0)\n', "AttributeError: 'Domain' object has no attribute 'filedata'\n"]
