### PR TITLE
Remove "type" field from searches for Comments

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1453,8 +1453,7 @@ def gen_global_query(obj,user,term,search_type="global",force_full=False):
                                                     "type": otypes[0],
                                                     "value": search_query}}}
     elif search_type == "byobject":
-        query = {'type': 'comment',
-                 'comment': search_query}
+        query = {'comment': search_query}
     elif search_type == "global":
         if type_ == "Sample":
             search_list.append(sample_queries["backdoor"])
@@ -1520,8 +1519,7 @@ def gen_global_query(obj,user,term,search_type="global",force_full=False):
                 ]
         elif type_ == "Comment":
             search_list = [
-                    {'comment': search_query,
-                     'type': 'comment'},
+                    {'comment': search_query},
                 ]
         elif type_ == "Campaign":
             search_list = [


### PR DESCRIPTION
Doing a global search, or a "Comments about Objects" advanced search, includes `{'type': 'comment'}` in the query. Since May 2014, the "type" field has not been included in new Comments, and therefore those Comments were not included in search results. This is related to PR #386.