### PR TITLE
Build swig from the 3.0.4 version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -63,7 +63,8 @@ then
     echo "Installation for OSX requires Homebrew. Please visit http://brew.sh/."
     exit
   }
-  brew install mongodb ssdeep upx p7zip libyaml pcre libxml2 openssl swig
+  brew install mongodb ssdeep upx p7zip libyaml pcre libxml2 openssl
+  brew install https://raw.githubusercontent.com/destijl/homebrew-versions/master/swig304.rb
 else
   echo "Unknown distro!"
   echo -e "Detected: $OS $VER"


### PR DESCRIPTION
Version 3.0.5 is broken on OSX. This is a temporary fix backporting to 3.0.4.