### PR TITLE
Ignoring venv Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ INSTALL_RECEIPT.json
 
 # Ignore MongoDB download
 *mongodb-*
+
+# Ignore VirtualEnv
+venv/*


### PR DESCRIPTION
Especially with the new bootstrapping script it’s nice to be able to use CRITs with a VirtualEnv. The most common convention is to name this ```venv``` so it’d be great to ignore that directory since we don’t want it checked in. 