### PR TITLE
Added server script

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,0 +1,19 @@
+#!/bin/sh
+# (c) 2015, The MITRE Corporation. All rights reserved.
+# Source code distributed pursuant to license agreement.
+#
+# Usage: script/server
+# This script starts the necessary services for a local or
+# development environment for CRITs.
+
+# If MongoDB isn't already running, ask to start it.
+# This can fail if MongoDB is running already but on a non-standard port.
+pgrep mongod &> /dev/null
+if [ $? == 1 ]
+then
+  echo "Attempting to start MongoDB"
+  sudo sh contrib/mongo/mongod_start.sh; break;
+fi
+
+echo "Attempting to start runserver on port 8080"
+python manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
Yet another short usability script. Traditionally if you have a ```bootstrap``` script for setting up a service you’d also have a ```server``` for restarting that service. This makes it easier to come back after a restart.