### PR TITLE
Change sh to bash (bootstrap script and README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Just run the following:
 
 ```bash
 
-    sh script/bootstrap
+    bash script/bootstrap
 ```
 
 ## Production CRITs install

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # (c) 2015, The MITRE Corporation. All rights reserved.
 # Source code distributed pursuant to license agreement.
 #


### PR DESCRIPTION
Ubuntu's sh links to dash, and I was getting an error about the <<< operator.