### PR TITLE
Fix issues with special chars in Campaign names

### DIFF
--- a/crits/campaigns/templates/campaign_detail.html
+++ b/crits/campaigns/templates/campaign_detail.html
@@ -9,7 +9,7 @@
 <script>
     var update_campaign_description = "{% url 'crits.campaigns.views.set_campaign_description' campaign_detail.id %}";
     var update_campaign_aliases = "{% url 'crits.campaigns.views.campaign_aliases' %}";
-    var campaign_name = "{{ campaign_detail.name }}";
+    var campaign_name = "{{ campaign_detail.name|safe }}";
     var is_admin = "{{ admin }}";
 </script>
 

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2044,7 +2044,8 @@ def jtable_ajax_list(col_obj,url,urlfieldparam,request,excludes=[],includes=[],q
                             doc[key] = ",".join(value)
                     else:
                         doc[key] = ""
-                doc[key] = html_escape(doc[key])
+                if key != urlfieldparam:
+                    doc[key] = html_escape(doc[key])
             if col_obj._meta['crits_type'] == "Comment":
                 mapper = {
                     "Actor": 'crits.actors.views.actor_detail',


### PR DESCRIPTION
If a Campaign name contains a special character like an apostrophe, the link on the Campaigns listing page will be broken because it has been html escaped. Further, if you access the Campaign details page, you will not be able to add an alias because the DB does not contain the template-auto-escaped form of the name.