### PR TITLE
Add support for listing campaigns by name.

### DIFF
--- a/crits/campaigns/handlers.py
+++ b/crits/campaigns/handlers.py
@@ -12,7 +12,7 @@ from crits.campaigns.forms import TTPForm
 from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.crits_mongoengine import EmbeddedCampaign, json_handler
 from crits.core.handlers import jtable_ajax_list, build_jtable
-from crits.core.handlers import csv_export
+from crits.core.handlers import csv_export, get_item_names
 from crits.core.mongo_tools import mongo_connector
 from crits.core.user_tools import user_sources, is_user_subscribed
 from crits.core.user_tools import is_user_favorite
@@ -30,6 +30,10 @@ from crits.targets.target import Target
 
 
 # Functions for top level Campaigns.
+def get_campaign_names_list(active):
+    listing = get_item_names(Campaign, bool(active))
+    return [c.name for c in listing]
+
 def get_campaign_details(campaign_name, analyst):
     """
     Generate the data to render the Campaign details template.

--- a/crits/campaigns/urls.py
+++ b/crits/campaigns/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import patterns
 
 urlpatterns = patterns('crits.campaigns.views',
     (r'^stats/$', 'campaign_stats'),
+    (r'^name_list/$', 'campaign_names'),
+    (r'^name_list/(?P<active_only>\S+)/$', 'campaign_names'),
     (r'^list/$', 'campaigns_listing'),
     (r'^list/(?P<option>\S+)/$', 'campaigns_listing'),
     (r'^details/(?P<campaign_name>.+?)/$', 'campaign_details'),

--- a/crits/campaigns/views.py
+++ b/crits/campaigns/views.py
@@ -75,8 +75,8 @@ def campaign_names(request, active_only=True):
 
     :param request: Django request object (Required)
     :type request: :class:`django.http.HttpRequest`
-    :param option: Whether we return active campaigns only (default)
-    :type option: str
+    :param active_only: Whether we return active campaigns only (default)
+    :type active_only: str
     :returns: :class:`django.http.HttpResponse`
     """
 

--- a/crits/campaigns/views.py
+++ b/crits/campaigns/views.py
@@ -18,6 +18,7 @@ from crits.campaigns.handlers import campaign_edit, campaign_remove
 from crits.campaigns.handlers import add_ttp, edit_ttp, remove_ttp
 from crits.campaigns.handlers import update_campaign_description, modify_campaign_aliases
 from crits.campaigns.handlers import generate_campaign_jtable, generate_campaign_csv
+from crits.campaigns.handlers import get_campaign_names_list
 from crits.core.user_tools import user_can_view_data
 from crits.stats.handlers import campaign_date_stats
 
@@ -50,6 +51,7 @@ def campaign_stats(request):
                                   {'campaign': campaign},
                                   RequestContext(request))
 
+
 @user_passes_test(user_can_view_data)
 def campaigns_listing(request, option=None):
     """
@@ -65,6 +67,21 @@ def campaigns_listing(request, option=None):
     if option == "csv":
         return generate_campaign_csv(request)
     return generate_campaign_jtable(request, option)
+
+@user_passes_test(user_can_view_data)
+def campaign_names(request, active_only=True):
+    """
+    Generate Campaign Listing.
+
+    :param request: Django request object (Required)
+    :type request: :class:`django.http.HttpRequest`
+    :param option: Whether we return active campaigns only (default)
+    :type option: str
+    :returns: :class:`django.http.HttpResponse`
+    """
+
+    campaign_list = get_campaign_names_list(active_only)
+    return HttpResponse(json.dumps(campaign_list), mimetype="application/json")
 
 @user_passes_test(user_can_view_data)
 def campaign_details(request, campaign_name):

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -657,6 +657,10 @@ def get_item_names(obj, active=None):
     :returns: :class:`crits.core.crits_mongoengine.CritsQuerySet`
     """
 
+    # Don't use this to get sources.
+    if isinstance(obj, SourceAccess):
+        return []
+
     if active is None:
        c = obj.objects().order_by('+name')
     else:


### PR DESCRIPTION
Add a view which calls into get_item_names() to fetch a list of
campaigns. It takes an optional flag to get active campaigns or inactive
campaigns.

While here, add a check in get_item_names() to make sure it can not be
used to enumerate sources.