### PR TITLE
Standards Parser now uses Handlers

### DIFF
--- a/crits/certificates/handlers.py
+++ b/crits/certificates/handlers.py
@@ -338,7 +338,8 @@ def handle_cert_file(filename, data, source_name, user=None,
         'success':      True,
         'message':      'Uploaded certificate',
         'md5':          md5,
-        'id':           str(cert.id)
+        'id':           str(cert.id),
+        'object':       cert
     }
 
     return status

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -495,17 +495,20 @@ def handle_email_fields(data, analyst, method):
     except:
         pass
 
-    for x in ('cc', 'to'):
-        y = data.get(x, None)
-        if isinstance(y, basestring):
-            if len(y) > 0:
-                tmp_y = y.split(',')
-                y_final = [ty.strip() for ty in tmp_y]
-                data[x] = y_final
-            else:
+    try:
+        for x in ('cc', 'to'):
+            y = data.get(x, None)
+            if isinstance(y, basestring):
+                if len(y) > 0:
+                    tmp_y = y.split(',')
+                    y_final = [ty.strip() for ty in tmp_y]
+                    data[x] = y_final
+                else:
+                    data[x] = []
+            elif not y:
                 data[x] = []
-        elif not y:
-            data[x] = []
+    except:
+        pass
 
     new_email = Email()
     new_email.merge(data)

--- a/crits/events/handlers.py
+++ b/crits/events/handlers.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from HTMLParser import HTMLParser
-import urllib2
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
@@ -308,7 +307,8 @@ def add_new_event(title, description, event_type, source, method, reference,
                                           title))
         result = {'success': True,
                   'message': message,
-                  'id': str(event.id)}
+                  'id': str(event.id),
+                  'object': event}
     except ValidationError, e:
         result = {'success': False,
                   'message': e}

--- a/crits/ips/handlers.py
+++ b/crits/ips/handlers.py
@@ -313,8 +313,8 @@ def add_new_ip(data, rowData, request, errors, is_validate_only=False, cache={})
     return result, errors, retVal
 
 def ip_add_update(ip_address, ip_type, source=None, source_method=None,
-                  source_reference=None, campaign=None, confidence='low', analyst=None,
-                  is_add_indicator=False, indicator_reference=None,
+                  source_reference=None, campaign=None, confidence='low',
+                  analyst=None, is_add_indicator=False, indicator_reference=None,
                   bucket_list=None, ticket=None, is_validate_only=False, cache={}):
     """
     Add/update an IP address.
@@ -377,7 +377,7 @@ def ip_add_update(ip_address, ip_type, source=None, source_method=None,
             if ':' not in cidr_parts[0] and int(cidr_parts[1]) > 32:
                 raise ValidationError("")
             validate_ipv46_address(cidr_parts[0])
-        except (ValidationError, ValueError) as cidr_error:
+        except (ValidationError, ValueError):
             return {"success": False, "message": "Invalid CIDR address."}
     else:
         return {"success": False, "message": "Invalid IP type."}

--- a/crits/objects/object_mapper.py
+++ b/crits/objects/object_mapper.py
@@ -66,6 +66,12 @@ class UnsupportedCRITsObjectTypeError(Exception):
     def __str__(self):
         return repr(self.message)
 
+def get_object_values(obj):
+    try:
+        return obj.values
+    except:
+        return [obj.value]
+
 def make_cybox_object(type_, name=None, value=None):
     """
     Converts type_, name, and value to a CybOX object instance.
@@ -322,20 +328,20 @@ def make_crits_object(cybox_obj):
     o.datatype = "string"
     if isinstance(cybox_obj, Account):
         o.object_type = "Account"
-        o.value = cybox_obj.description.values
+        o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, Address):
         o.object_type = "Address"
         o.name = str(cybox_obj.category)
-        o.value = cybox_obj.address_value.values
+        o.value = get_object_values(cybox_obj.address_value)
         return o
     elif isinstance(cybox_obj, API):
         o.object_type = "API"
-        o.value = cybox_obj.description.values
+        o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, Artifact):
         o.object_type = "Artifact"
-        o.value = cybox_obj.data.values
+        o.value = get_object_values(cybox_obj.data)
         if cybox_obj.type_ == Artifact.TYPE_GENERIC:
             o.name = "Data Region"
             return o
@@ -347,30 +353,30 @@ def make_crits_object(cybox_obj):
             return o
     elif isinstance(cybox_obj, Code):
         o.object_type = "Code"
-        o.value = cybox_obj.code_segment.values
         o.name = str(cybox_obj.type)
+        o.value = get_object_values(cybox_obj.code_segment)
         return o
     elif isinstance(cybox_obj, Disk):
         o.object_type = "Disk"
         o.name = str(cybox_obj.type)
-        o.value = cybox_obj.disk_name.values
+        o.value = get_object_values(cybox_obj.disk_name)
         return o
     elif isinstance(cybox_obj, DiskPartition):
         o.object_type = "Disk Partition"
         o.name = str(cybox_obj.type)
-        o.value = cybox_obj.device_name.values
+        o.value = get_object_values(cybox_obj.device_name)
         return o
     elif isinstance(cybox_obj, DNSQuery):
         o.object_type = "DNS Query"
-        o.value = cybox_obj.question.qname.value.values
+        o.value = get_object_values(cybox_obj.question.qname)
         return o
     elif isinstance(cybox_obj, DNSRecord):
         o.object_type = "DNS Record"
-        o.value = cybox_obj.description.values
+        o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, DomainName):
         o.object_type = "URI - Domain Name"
-        o.value = cybox_obj.value.values
+        o.value = get_object_values(cybox_obj.value)
         return o
     elif isinstance(cybox_obj, EmailMessage):
         o.object_type = "Email Message"
@@ -378,122 +384,121 @@ def make_crits_object(cybox_obj):
         return o
     elif isinstance(cybox_obj, GUIDialogbox):
         o.object_type = "GUI Dialogbox"
-        o.value = cybox_obj.box_text.values
+        o.value = get_object_values(cybox_obj.box_text)
         return o
     elif isinstance(cybox_obj, GUIWindow):
         o.object_type = "GUI Window"
-        o.value = cybox_obj.window_display_name.values
+        o.value = get_object_values(cybox_obj.window_display_name)
         return o
     elif isinstance(cybox_obj, Library):
         o.object_type = "Library"
         o.name = str(cybox_obj.type)
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, Memory):
         o.object_type = "Memory"
-        o.value = cybox_obj.memory_source.values
+        o.value = get_object_values(cybox_obj.memory_source)
         return o
     elif isinstance(cybox_obj, Mutex):
         o.object_type = "Mutex"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, NetworkConnection):
         o.object_type = "Network Connection"
-        o.value = cybox_obj.layer7_protocol.values
+        o.value = get_object_values(cybox_obj.layer7_protocol)
         return o
     elif isinstance(cybox_obj, Pipe):
         o.object_type = "Pipe"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, Port):
         o.object_type = "Port"
-        o.value = cybox_obj.port_value.values
+        o.value = get_object_values(cybox_obj.port_value)
         return o
     elif isinstance(cybox_obj, Process):
         o.object_type = "Process"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, String):
         o.object_type = "String"
-        o.value = cybox_obj.value.values
+        o.value = get_object_values(cybox_obj.value)
         return o
     elif isinstance(cybox_obj, System):
         o.object_type = "System"
-        o.value = cybox_obj.hostname.values
+        o.value = get_object_values(cybox_obj.hostname)
         return o
     elif isinstance(cybox_obj, URI):
         o.object_type = "URI - URL"
         o.name = cybox_obj.type_
-        o.value = cybox_obj.value.values
+        o.value = get_object_values(cybox_obj.value)
         return o
     elif isinstance(cybox_obj, UserAccount):
         o.object_type = "User Account"
-        o.value = cybox_obj.username.values
+        o.value = get_object_values(cybox_obj.username)
         return o
     elif isinstance(cybox_obj, Volume):
         o.object_type = "Volume"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, WinDriver):
         o.object_type = "Win Driver"
-        o.value = cybox_obj.driver_name.values
+        o.value = get_object_values(cybox_obj.driver_name)
         return o
     elif isinstance(cybox_obj, WinEventLog):
         o.object_type = "Win Event Log"
-        o.value = cybox_obj.log.values
+        o.value = get_object_values(cybox_obj.log)
         return o
     elif isinstance(cybox_obj, WinEvent):
         o.object_type = "Win Event"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, WinHandle):
         o.object_type = "Win Handle"
         o.name = str(cybox_obj.type_)
-        o.value = cybox_obj.object_address.values
+        o.value = get_object_values(cybox_obj.object_address)
         return o
     elif isinstance(cybox_obj, WinKernelHook):
         o.object_type = "Win Kernel Hook"
-        o.value = cybox_obj.description.values
+        o.value = get_object_values(cybox_obj.description)
         return o
     elif isinstance(cybox_obj, WinMailslot):
         o.object_type = "Win Mailslot"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, WinNetworkShare):
         o.object_type = "Win Network Share"
-        o.value = cybox_obj.local_path.values
+        o.value = get_object_values(cybox_obj.local_path)
         return o
     elif isinstance(cybox_obj, WinProcess):
         o.object_type = "Win Process"
-        o.value = cybox_obj.window_title.values
+        o.value = get_object_values(cybox_obj.window_title)
         return o
     elif isinstance(cybox_obj, WinRegistryKey):
         o.object_type = "Win Registry Key"
-        o.value = cybox_obj.key.values
+        o.value = get_object_values(cybox_obj.key)
         return o
     elif isinstance(cybox_obj, WinService):
         o.object_type = "Win Service"
-        o.value = cybox_obj.service_name.values
+        o.value = get_object_values(cybox_obj.service_name)
         return o
     elif isinstance(cybox_obj, WinSystem):
         o.object_type = "Win System"
-        o.value = cybox_obj.product_name.values
+        o.value = get_object_values(cybox_obj.product_name)
         return o
     elif isinstance(cybox_obj, WinTask):
         o.object_type = "Win Task"
-        o.value = cybox_obj.name.values
+        o.value = get_object_values(cybox_obj.name)
         return o
     elif isinstance(cybox_obj, WinUser):
         o.object_type = "Win User Account"
-        o.value = cybox_obj.security_id.values
+        o.value = get_object_values(cybox_obj.security_id)
         return o
     elif isinstance(cybox_obj, WinVolume):
         o.object_type = "Win Volume"
-        o.value = cybox_obj.drive_letter.values
+        o.value = get_object_values(cybox_obj.drive_letter)
         return o
     elif isinstance(cybox_obj, X509Certificate):
         o.object_type = "X509 Certificate"
-        o.value = cybox_obj.raw_certificate.values
+        o.value = get_object_values(cybox_obj.raw_certificate)
         return o
     raise UnsupportedCRITsObjectTypeError(cybox_obj)
-

--- a/crits/objects/object_mapper.py
+++ b/crits/objects/object_mapper.py
@@ -322,20 +322,20 @@ def make_crits_object(cybox_obj):
     o.datatype = "string"
     if isinstance(cybox_obj, Account):
         o.object_type = "Account"
-        o.value = str(cybox_obj.description)
+        o.value = cybox_obj.description.values
         return o
     elif isinstance(cybox_obj, Address):
         o.object_type = "Address"
         o.name = str(cybox_obj.category)
-        o.value = str(cybox_obj.address_value)
+        o.value = cybox_obj.address_value.values
         return o
     elif isinstance(cybox_obj, API):
         o.object_type = "API"
-        o.value = str(cybox_obj.description)
+        o.value = cybox_obj.description.values
         return o
     elif isinstance(cybox_obj, Artifact):
         o.object_type = "Artifact"
-        o.value = str(cybox_obj.data)
+        o.value = cybox_obj.data.values
         if cybox_obj.type_ == Artifact.TYPE_GENERIC:
             o.name = "Data Region"
             return o
@@ -347,153 +347,153 @@ def make_crits_object(cybox_obj):
             return o
     elif isinstance(cybox_obj, Code):
         o.object_type = "Code"
-        o.value = str(cybox_obj.code_segment)
+        o.value = cybox_obj.code_segment.values
         o.name = str(cybox_obj.type)
         return o
     elif isinstance(cybox_obj, Disk):
         o.object_type = "Disk"
         o.name = str(cybox_obj.type)
-        o.value = str(cybox_obj.disk_name)
+        o.value = cybox_obj.disk_name.values
         return o
     elif isinstance(cybox_obj, DiskPartition):
         o.object_type = "Disk Partition"
         o.name = str(cybox_obj.type)
-        o.value = str(cybox_obj.device_name)
+        o.value = cybox_obj.device_name.values
         return o
     elif isinstance(cybox_obj, DNSQuery):
         o.object_type = "DNS Query"
-        o.value = str(cybox_obj.question.qname.value)
+        o.value = cybox_obj.question.qname.value.values
         return o
     elif isinstance(cybox_obj, DNSRecord):
         o.object_type = "DNS Record"
-        o.value = str(cybox_obj.description)
+        o.value = cybox_obj.description.values
         return o
     elif isinstance(cybox_obj, DomainName):
-        o.object_type = "Domain Name"
-        o.value = str(cybox_obj.value)
+        o.object_type = "URI - Domain Name"
+        o.value = cybox_obj.value.values
         return o
     elif isinstance(cybox_obj, EmailMessage):
         o.object_type = "Email Message"
-        o.value = str(cybox_obj.raw_body)
+        o.value = [cybox_obj.raw_body]
         return o
     elif isinstance(cybox_obj, GUIDialogbox):
         o.object_type = "GUI Dialogbox"
-        o.value = str(cybox_obj.box_text)
+        o.value = cybox_obj.box_text.values
         return o
     elif isinstance(cybox_obj, GUIWindow):
         o.object_type = "GUI Window"
-        o.value = str(cybox_obj.window_display_name)
+        o.value = cybox_obj.window_display_name.values
         return o
     elif isinstance(cybox_obj, Library):
         o.object_type = "Library"
         o.name = str(cybox_obj.type)
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, Memory):
         o.object_type = "Memory"
-        o.value = str(cybox_obj.memory_source)
+        o.value = cybox_obj.memory_source.values
         return o
     elif isinstance(cybox_obj, Mutex):
         o.object_type = "Mutex"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, NetworkConnection):
         o.object_type = "Network Connection"
-        o.value = str(cybox_obj.layer7_protocol)
+        o.value = cybox_obj.layer7_protocol.values
         return o
     elif isinstance(cybox_obj, Pipe):
         o.object_type = "Pipe"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, Port):
         o.object_type = "Port"
-        o.value = str(cybox_obj.port_value)
+        o.value = cybox_obj.port_value.values
         return o
     elif isinstance(cybox_obj, Process):
         o.object_type = "Process"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, String):
         o.object_type = "String"
-        o.value = str(cybox_obj.value)
+        o.value = cybox_obj.value.values
         return o
     elif isinstance(cybox_obj, System):
         o.object_type = "System"
-        o.value = str(cybox_obj.hostname)
+        o.value = cybox_obj.hostname.values
         return o
     elif isinstance(cybox_obj, URI):
-        o.object_type = "URI"
-        o.name = str(cybox_obj.type_)
-        o.value = str(cybox_obj.value)
+        o.object_type = "URI - URL"
+        o.name = cybox_obj.type_
+        o.value = cybox_obj.value.values
         return o
     elif isinstance(cybox_obj, UserAccount):
         o.object_type = "User Account"
-        o.value = str(cybox_obj.username)
+        o.value = cybox_obj.username.values
         return o
     elif isinstance(cybox_obj, Volume):
         o.object_type = "Volume"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, WinDriver):
         o.object_type = "Win Driver"
-        o.value = str(cybox_obj.driver_name)
+        o.value = cybox_obj.driver_name.values
         return o
     elif isinstance(cybox_obj, WinEventLog):
         o.object_type = "Win Event Log"
-        o.value = str(cybox_obj.log)
+        o.value = cybox_obj.log.values
         return o
     elif isinstance(cybox_obj, WinEvent):
         o.object_type = "Win Event"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, WinHandle):
         o.object_type = "Win Handle"
         o.name = str(cybox_obj.type_)
-        o.value = str(cybox_obj.object_address)
+        o.value = cybox_obj.object_address.values
         return o
     elif isinstance(cybox_obj, WinKernelHook):
         o.object_type = "Win Kernel Hook"
-        o.value = str(cybox_obj.description)
+        o.value = cybox_obj.description.values
         return o
     elif isinstance(cybox_obj, WinMailslot):
         o.object_type = "Win Mailslot"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, WinNetworkShare):
         o.object_type = "Win Network Share"
-        o.value = str(cybox_obj.local_path)
+        o.value = cybox_obj.local_path.values
         return o
     elif isinstance(cybox_obj, WinProcess):
         o.object_type = "Win Process"
-        o.value = str(cybox_obj.window_title)
+        o.value = cybox_obj.window_title.values
         return o
     elif isinstance(cybox_obj, WinRegistryKey):
         o.object_type = "Win Registry Key"
-        o.value = str(cybox_obj.key)
+        o.value = cybox_obj.key.values
         return o
     elif isinstance(cybox_obj, WinService):
         o.object_type = "Win Service"
-        o.value = str(cybox_obj.service_name)
+        o.value = cybox_obj.service_name.values
         return o
     elif isinstance(cybox_obj, WinSystem):
         o.object_type = "Win System"
-        o.value = str(cybox_obj.product_name)
+        o.value = cybox_obj.product_name.values
         return o
     elif isinstance(cybox_obj, WinTask):
         o.object_type = "Win Task"
-        o.value = str(cybox_obj.name)
+        o.value = cybox_obj.name.values
         return o
     elif isinstance(cybox_obj, WinUser):
         o.object_type = "Win User Account"
-        o.value = str(cybox_obj.security_id)
+        o.value = cybox_obj.security_id.values
         return o
     elif isinstance(cybox_obj, WinVolume):
         o.object_type = "Win Volume"
-        o.value = str(cybox_obj.drive_letter)
+        o.value = cybox_obj.drive_letter.values
         return o
     elif isinstance(cybox_obj, X509Certificate):
         o.object_type = "X509 Certificate"
-        o.value = str(cybox_obj.raw_certificate)
+        o.value = cybox_obj.raw_certificate.values
         return o
     raise UnsupportedCRITsObjectTypeError(cybox_obj)
 

--- a/crits/pcaps/handlers.py
+++ b/crits/pcaps/handlers.py
@@ -349,6 +349,7 @@ def handle_pcap_file(filename, data, source_name, user=None,
         'message':      'Uploaded pcap',
         'md5':          md5,
         'id':           str(pcap.id),
+        'object':       pcap
     }
 
     return status

--- a/crits/raw_data/handlers.py
+++ b/crits/raw_data/handlers.py
@@ -419,6 +419,7 @@ def handle_raw_data_file(data, source_name, user=None,
         'success':      True,
         'message':      'Uploaded raw_data',
         '_id':          raw_data.id,
+        'object':       raw_data
     }
 
     return status

--- a/crits/raw_data/raw_data.py
+++ b/crits/raw_data/raw_data.py
@@ -248,7 +248,7 @@ class RawData(CritsBaseAttributes, CritsSourceDocument, Document):
             To get the cybox object as xml or json, call to_xml() or
             to_json(), respectively, on the resulting CybOX object.
         """
-        obj = Artifact(self.data, Artifact.TYPE_FILE)
+        obj = Artifact(self.data.encode('utf-8'), Artifact.TYPE_FILE)
         obj.packaging.append(Base64Encoding())
         obs = Observable(obj)
         obs.description = self.description

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -1,10 +1,21 @@
+import datetime, base64
+
 from StringIO import StringIO
 
 from crits.actors.actor import Actor
-from crits.events.event import Event
+from crits.actors.handlers import add_new_actor, update_actor_tags
+from crits.certificates.handlers import handle_cert_file
+from crits.domains.handlers import upsert_domain, get_domain
+from crits.emails.handlers import handle_email_fields
+from crits.events.handlers import add_new_event
 from crits.indicators.indicator import Indicator
+from crits.indicators.handlers import handle_indicator_ind
+from crits.ips.handlers import ip_add_update
+from crits.objects.object_mapper import make_crits_object
+from crits.pcaps.handlers import handle_pcap_file
+from crits.raw_data.handlers import handle_raw_data_file
+from crits.samples.handlers import handle_file
 from crits.core.crits_mongoengine import EmbeddedSource
-from crits.core.class_mapper import class_from_type
 from crits.core.handlers import does_source_exist
 
 from cybox.objects.artifact_object import Artifact
@@ -13,7 +24,8 @@ from cybox.objects.domain_name_object import DomainName
 from cybox.objects.email_message_object import EmailMessage
 from cybox.objects.file_object import File
 
-from stix.core import STIXPackage
+from stix.common import StructuredText
+from stix.core import STIXPackage, STIXHeader
 
 class STIXParserException(Exception):
     """
@@ -101,13 +113,37 @@ class STIXParser():
         self.source.instances.append(self.source_instance)
 
         if make_event:
-            event = Event.from_stix(stix_package=self.package)
-            try:
-                event.add_source(self.source)
-                event.save(username=self.source_instance.analyst)
-                self.imported.append((Event._meta['crits_type'], event))
-            except Exception, e:
-                self.failed.append((e.message, type(event).__name__, event.id_))
+            title = "STIX Document %s" % self.package.id_
+            event_type = "Collective Threat Intelligence"
+            date = datetime.datetime.now()
+            description = str(date)
+            header = self.package.stix_header
+            if isinstance(header, STIXHeader):
+                if header.title:
+                    title = header.title
+                if hasattr(header, 'package_intents'):
+                    event_type = str(header.package_intents[0])
+                description = header.description
+                if isinstance(description, StructuredText):
+                    try:
+                        description = description.to_dict()
+                    except:
+                        pass
+            res = add_new_event(title,
+                                description,
+                                event_type,
+                                self.source.name,
+                                self.source_instance.method,
+                                self.source_instance.reference,
+                                date,
+                                self.source_instance.analyst)
+            if res['success']:
+                self.imported.append(('Event',
+                                      res['object']))
+            else:
+                self.failed.append((res['message'],
+                                    "STIX Event",
+                                    ""))
 
         if self.package.indicators:
             self.parse_indicators(self.package.indicators)
@@ -125,12 +161,49 @@ class STIXParser():
         :param threat_actors: List of STIX ThreatActors.
         :type threat_actors: List of STIX ThreatActors.
         """
+        from stix.threat_actor import ThreatActor
+        analyst = self.source_instance.analyst
         for threat_actor in threat_actors: # for each STIX ThreatActor
             try: # create CRITs Actor from ThreatActor
-                obj = Actor.from_stix(threat_actor)
-                obj.add_source(self.source)
-                obj.save(username=self.source_instance.analyst)
-                self.imported.append((Actor._meta['crits_type'], obj))
+                if isinstance(threat_actor, ThreatActor):
+                    name = str(threat_actor.title)
+                    description = str(threat_actor.description)
+                    res = add_new_actor(name=name,
+                                        description=description,
+                                        source=[self.source],
+                                        analyst=analyst)
+                    if res['success']:
+                        sl = ml = tl = il = []
+                        for s in threat_actor.sophistications:
+                            sl.append(str(s.value))
+                        update_actor_tags(res['id'],
+                                            'ActorSophistication',
+                                            sl,
+                                            analyst)
+                        for m in threat_actor.motivations:
+                            ml.append(str(m.value))
+                        update_actor_tags(res['id'],
+                                            'ActorMotivation',
+                                            ml,
+                                            analyst)
+                        for t in threat_actor.types:
+                            tl.append(str(t.value))
+                        update_actor_tags(res['id'],
+                                            'ActorThreatType',
+                                            tl,
+                                            analyst)
+                        for i in threat_actor.intended_effects:
+                            il.append(str(i.value))
+                        update_actor_tags(res['id'],
+                                            'ActorIntendedEffect',
+                                            il,
+                                            analyst)
+                        obj = Actor.objects(id=res['id']).first()
+                        self.imported.append((Actor._meta['crits_type'], obj))
+                    else:
+                        self.failed.append((res['message'],
+                                            type(threat_actor).__name__,
+                                            "")) # note for display in UI
             except Exception, e:
                 self.failed.append((e.message, type(threat_actor).__name__,
                                     "")) # note for display in UI
@@ -142,14 +215,31 @@ class STIXParser():
         :param indicators: List of STIX indicators.
         :type indicators: List of STIX indicators.
         """
+
+        analyst = self.source_instance.analyst
         for indicator in indicators: # for each STIX indicator
             for observable in indicator.observables: # get each observable from indicator (expecting only 1)
                 try: # create CRITs Indicator from observable
                     item = observable.object_.properties
-                    obj = Indicator.from_cybox(item)
-                    obj.add_source(self.source)
-                    obj.save(username=self.source_instance.analyst)
-                    self.imported.append((Indicator._meta['crits_type'], obj))
+                    obj = make_crits_object(item)
+                    if obj.name and obj.name != obj.object_type:
+                        ind_type = "%s - %s" % (obj.object_type, obj.name)
+                    else:
+                        ind_type = obj.object_type
+                    res = handle_indicator_ind(obj.value,
+                                               self.source,
+                                               None,
+                                               ind_type,
+                                               analyst,
+                                               add_domain=True,
+                                               add_relationship=True)
+                    if res['success']:
+                        self.imported.append((Indicator._meta['crits_type'],
+                                              res['object']))
+                    else:
+                        self.failed.append((res['message'],
+                                            type(item).__name__,
+                                            item.parent.id_)) # note for display in UI
                 except Exception, e: # probably caused by cybox object we don't handle
                     self.failed.append((e.message, type(item).__name__, item.parent.id_)) # note for display in UI
 
@@ -160,45 +250,149 @@ class STIXParser():
         :param observables: List of STIX observables.
         :type observables: List of STIX observables.
         """
+
+        analyst = self.source_instance.analyst
         for obs in observables: # for each STIX observable
             if not obs.object_ or not obs.object_.properties:
-                self.failed.append(("No valid object_properties was found!", type(obs).__name__, obs.id_)) # note for display in UI
+                self.failed.append(("No valid object_properties was found!",
+                                    type(obs).__name__,
+                                    obs.id_)) # note for display in UI
                 continue
             try: # try to create CRITs object from observable
                 item = obs.object_.properties
-                cls = self.get_crits_type(item) # determine which CRITs class matches
-                obj = cls.from_cybox(obs)
-                obj.add_source(self.source)
-                obj.save(username=self.source_instance.analyst)
-                self.imported.append((cls._meta['crits_type'], obj)) # use class to parse object
+                if isinstance(item, Address):
+                    imp_type = "IP"
+                    ip = str(item.address_value)
+                    iptype = "Address - %s" % item.category
+                    res = ip_add_update(ip,
+                                        iptype,
+                                        [self.source],
+                                        analyst=analyst,
+                                        is_add_indicator=True)
+                elif isinstance(item, DomainName):
+                    imp_type = "Domain"
+                    (sdomain, domain) = get_domain(str(item.value))
+                    res = upsert_domain(sdomain,
+                                        domain,
+                                        [self.source],
+                                        username=analyst)
+                elif isinstance(item, Artifact):
+                    # Not sure if this is right, and I believe these can be
+                    # encoded in a couple different ways.
+                    imp_type = "RawData"
+                    rawdata = base64.b64decode(item.data)
+                    description = str(item.description)
+                    # TODO: find out proper ways to determine title, datatype,
+                    #       tool_name, tool_version
+                    title = "Artifact for Event: STIX Document %s" % self.package.id_
+                    res = handle_raw_data_file(rawdata,
+                                               self.source.name,
+                                               user=analyst,
+                                               description=description,
+                                               title=title,
+                                               data_type="Text",
+                                               tool_name="TAXII",
+                                               tool_version=None,
+                                               method=self.source_instance.method,
+                                               reference=self.source_instance.reference)
+                elif (isinstance(item, File) and
+                      item.custom_properties and
+                      item.custom_properties[0].name == "crits_type" and
+                      item.custom_properties[0]._value == "Certificate"):
+                    imp_type = "Certificate"
+                    description = str(item.description)
+                    filename = str(item.file_name)
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if isinstance(obj.properties, Artifact):
+                            data = base64.b64decode(obj.properties.data)
+                    res = handle_cert_file(filename,
+                                           data,
+                                           self.source,
+                                           user=analyst,
+                                           description=description)
+                elif isinstance(item, File) and self.has_network_artifact(item):
+                    imp_type = "PCAP"
+                    description = str(item.description)
+                    filename = str(item.file_name)
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if (isinstance(obj.properties, Artifact) and
+                            obj.properties.type_ == Artifact.TYPE_NETWORK):
+                            data = base64.b64decode(obj.properties.data)
+                    res = handle_pcap_file(filename,
+                                           data,
+                                           self.source,
+                                           user=analyst,
+                                           description=description)
+                elif isinstance(item, File):
+                    imp_type = "Sample"
+                    filename = str(item.file_name)
+                    md5 = item.md5
+                    data = None
+                    for obj in item.parent.related_objects:
+                        if (isinstance(obj.properties, Artifact) and
+                            obj.properties.type_ == Artifact.TYPE_FILE):
+                            data = base64.b64decode(obj.properties.data)
+                    res = handle_file(filename,
+                                      data,
+                                      self.source,
+                                      user=analyst,
+                                      md5_digest=md5,
+                                      is_return_only_md5=False)
+                elif isinstance(item, EmailMessage):
+                    imp_type = "Email"
+                    data = {}
+                    data['source'] = self.source.name
+                    data['source_method'] = self.source_instance.method
+                    data['source_reference'] = self.source_instance.reference
+                    data['message_id'] = str(item.header.message_id)
+                    data['subject'] = str(item.header.subject)
+                    data['sender'] = str(item.header.sender)
+                    data['reply_to'] = str(item.header.reply_to)
+                    data['x_originating_ip'] = str(item.header.x_originating_ip)
+                    data['x_mailer'] = str(item.header.x_mailer)
+                    data['boundary'] = str(item.header.boundary)
+                    data['raw_body'] = str(item.raw_body)
+                    data['raw_header'] = str(item.raw_header)
+                    data['helo'] = str(item.email_server)
+                    data['from_address'] = str(item.header.from_)
+                    data['date'] = item.header.date
+                    data['to'] = [str(r) for r in item.header.to.to_list()]
+                    res = handle_email_fields(data,
+                                              analyst,
+                                              "TAXII")
+                else: # try to parse all other possibilities as Indicator
+                    imp_type = "Indicator"
+                    obj = make_crits_object(item)
+                    if obj.name and obj.name != obj.object_type:
+                        ind_type = "%s - %s" % (obj.object_type, obj.name)
+                    else:
+                        ind_type = obj.object_type
+                    res = handle_indicator_ind(obj.value,
+                                               self.source,
+                                               None,
+                                               ind_type,
+                                               analyst,
+                                               add_domain=True,
+                                               add_relationship=True)
+                if res['success']:
+                    self.imported.append((imp_type,
+                                          res['object'])) # use class to parse object
+                else:
+                    if 'reason' in res:
+                        msg = res['reason']
+                    elif 'message' in res:
+                        msg = res['message']
+                    else:
+                        msg = "Failed for unknown reason."
+                    self.failed.append((msg,
+                                        type(obs).__name__,
+                                        obs.id_)) # note for display in UI
             except Exception, e: # probably caused by cybox object we don't handle
-                self.failed.append((e.message, type(item).__name__, item.parent.id_)) # note for display in UI
-
-    def get_crits_type(self, c_obj):
-        """
-        Get the class that the given cybox object should be interpreted as during import.
-
-        :param c_obj: A CybOX object.
-        :type c_obj: An instance of one of the various CybOX object classes.
-        :returns: The CRITs class to use to import the given CybOX object.
-        """
-        if isinstance(c_obj, Address):
-            imp_type = "IP"
-        elif isinstance(c_obj, DomainName):
-            imp_type = "Domain"
-        elif isinstance(c_obj, Artifact):
-            imp_type = "RawData"
-        elif isinstance(c_obj, File) and c_obj.custom_properties and c_obj.custom_properties[0].name == "crits_type" and c_obj.custom_properties[0]._value == "Certificate":
-            imp_type = "Certificate"
-        elif isinstance(c_obj, File) and self.has_network_artifact(c_obj):
-            imp_type = "PCAP"
-        elif isinstance(c_obj, File):
-            imp_type = "Sample"
-        elif isinstance(c_obj, EmailMessage):
-            imp_type = "Email"
-        else: # try to parse all other possibilities as Indicator
-            imp_type = "Indicator"
-        return class_from_type(imp_type)
+                self.failed.append((e.message,
+                                    type(item).__name__,
+                                    item.parent.id_)) # note for display in UI
 
     def has_network_artifact(self, file_obj):
         """

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -1,4 +1,4 @@
-import datetime, base64
+import datetime
 
 from StringIO import StringIO
 
@@ -290,33 +290,33 @@ class STIXParser():
                     # Not sure if this is right, and I believe these can be
                     # encoded in a couple different ways.
                     imp_type = "RawData"
-                    rawdata = base64.b64decode(item.data)
-                    description = str(item.description)
+                    rawdata = item.data.decode('utf-8')
+                    description = "None"
                     # TODO: find out proper ways to determine title, datatype,
                     #       tool_name, tool_version
                     title = "Artifact for Event: STIX Document %s" % self.package.id_
                     res = handle_raw_data_file(rawdata,
-                                               self.source.name,
-                                               user=analyst,
-                                               description=description,
-                                               title=title,
-                                               data_type="Text",
-                                               tool_name="STIX",
-                                               tool_version=None,
-                                               method=self.source_instance.method,
-                                               reference=self.source_instance.reference)
+                                            self.source.name,
+                                            user=analyst,
+                                            description=description,
+                                            title=title,
+                                            data_type="Text",
+                                            tool_name="STIX",
+                                            tool_version=None,
+                                            method=self.source_instance.method,
+                                            reference=self.source_instance.reference)
                     self.parse_res(imp_type, obs, res)
                 elif (isinstance(item, File) and
                       item.custom_properties and
                       item.custom_properties[0].name == "crits_type" and
                       item.custom_properties[0]._value == "Certificate"):
                     imp_type = "Certificate"
-                    description = str(item.description)
+                    description = "None"
                     filename = str(item.file_name)
                     data = None
                     for obj in item.parent.related_objects:
                         if isinstance(obj.properties, Artifact):
-                            data = base64.b64decode(obj.properties.data)
+                            data = obj.properties.data
                     res = handle_cert_file(filename,
                                            data,
                                            self.source,
@@ -325,13 +325,13 @@ class STIXParser():
                     self.parse_res(imp_type, obs, res)
                 elif isinstance(item, File) and self.has_network_artifact(item):
                     imp_type = "PCAP"
-                    description = str(item.description)
+                    description = "None"
                     filename = str(item.file_name)
                     data = None
                     for obj in item.parent.related_objects:
                         if (isinstance(obj.properties, Artifact) and
                             obj.properties.type_ == Artifact.TYPE_NETWORK):
-                            data = base64.b64decode(obj.properties.data)
+                            data = obj.properties.data
                     res = handle_pcap_file(filename,
                                            data,
                                            self.source,
@@ -346,7 +346,7 @@ class STIXParser():
                     for obj in item.parent.related_objects:
                         if (isinstance(obj.properties, Artifact) and
                             obj.properties.type_ == Artifact.TYPE_FILE):
-                            data = base64.b64decode(obj.properties.data)
+                            data = obj.properties.data
                     res = handle_file(filename,
                                       data,
                                       self.source,

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -268,7 +268,7 @@ class STIXParser():
                                          'ipv4-netmask', 'ipv6-addr',
                                          'ipv6-net', 'ipv6-netmask'):
                         imp_type = "IP"
-                        for value in item.address_value.values():
+                        for value in item.address_value.values:
                             ip = str(value).strip()
                             iptype = "Address - %s" % item.category
                             res = ip_add_update(ip,
@@ -279,7 +279,7 @@ class STIXParser():
                             self.parse_res(imp_type, obs, res)
                 if isinstance(item, DomainName):
                     imp_type = "Domain"
-                    for value in item.value.values():
+                    for value in item.value.values:
                         (sdomain, domain) = get_domain(str(value.strip()))
                         res = upsert_domain(sdomain,
                                             domain,
@@ -372,7 +372,7 @@ class STIXParser():
                         data['x_mailer'] = str(item.header.x_mailer)
                         data['boundary'] = str(item.header.boundary)
                         data['from_address'] = str(item.header.from_)
-                        data['date'] = item.header.date
+                        data['date'] = item.header.date.value
                         if item.header.to:
                             data['to'] = [str(r) for r in item.header.to.to_list()]
                     res = handle_email_fields(data,

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -372,7 +372,8 @@ class STIXParser():
                         data['boundary'] = str(item.header.boundary)
                         data['from_address'] = str(item.header.from_)
                         data['date'] = item.header.date
-                        data['to'] = [str(r) for r in item.header.to.to_list()]
+                        if item.header.to:
+                            data['to'] = [str(r) for r in item.header.to.to_list()]
                     res = handle_email_fields(data,
                                             analyst,
                                             "STIX")

--- a/crits/standards/templates/import_results.html
+++ b/crits/standards/templates/import_results.html
@@ -16,11 +16,12 @@
                     </td>
                 </tr>
             {% endfor %}
+    {% else %}
+        <tr>
+            <td colspan="2" style="text-align: center"><b>Nothing Imported</b></td>
+        </tr>
     {% endif %}
-{% if failed %}
-    {% if imported %}
-        <tr><td colspan="2">&nbsp;</td></tr>
-    {% endif %}
+    {% if failed %}
     <tr>
         <td colspan="2" style="text-align: center"><b>Failed</b></td>
     </tr>
@@ -35,6 +36,10 @@
                     </td>
                 </tr>
             {% endfor %}
-{% endif %}
+    {% else %}
+        <tr>
+            <td colspan="2" style="text-align: center"><b>Nothing Failed</b></td>
+        </tr>
+    {% endif %}
     </tbody>
 </table>


### PR DESCRIPTION
For a long time we parsed STIX/CybOX and just created a new CRITs object or returned the current one in the database. The main issue with this is that it breaks the philosophy of running all of our data through handlers so no matter where you come from (web, API, command-line) you will be guaranteed that the same code is handling the same type of feature. This caused problems like creating Indicators but doing all of the automated fun stuff that would come along with creating an Indicator through the UI.

This change makes the Standards Parser parse out the necessary values and submit them as arguments into the appropriate handler for creating new content.

This might make the "from_stix()" or "from_cybox()" class methods deprecated, but I've left them in there for the time being until we are 100% sure we are good to remove them.