### PR TITLE
Initial commit for new delete approach

### DIFF
--- a/crits/campaigns/api.py
+++ b/crits/campaigns/api.py
@@ -2,11 +2,25 @@ from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import BadRequest
+from bson.objectid import ObjectId
 
 from crits.campaigns.campaign import Campaign
-from crits.campaigns.handlers import add_campaign
+from crits.domains.domain import Domain
+from crits.emails.email import Email
+from crits.events.event import Event
+from crits.indicators.indicator import Indicator
+from crits.ips.ip import IP
+from crits.pcaps.pcap import PCAP
+from crits.samples.sample import Sample
+from crits.raw_data.raw_data import RawData
+from crits.actors.actor import Actor
+
+from crits.campaigns.handlers import add_campaign, campaign_remove, remove_campaign
 from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
 from crits.core.api import CRITsSerializer, CRITsAPIResource
+from crits.core.class_mapper import class_from_type
+from crits.core.user_tools import is_admin, user_sources
+
 
 
 class CampaignResource(CRITsAPIResource):
@@ -18,7 +32,7 @@ class CampaignResource(CRITsAPIResource):
 
     class Meta:
         object_class = Campaign
-        allowed_methods = ('get', 'post')
+        allowed_methods = ('get', 'post','delete')
         resource_name = "campaigns"
         authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
                                              CRITsSessionAuthentication())
@@ -79,4 +93,52 @@ class CampaignResource(CRITsAPIResource):
             content['return_code'] = 0
 
         content['message'] = result['message']
+        self.crits_response(content)
+
+
+    def delete_detail(self, request, **kwargs):
+        """
+        This will delete a specific campaign ID record.
+        It will also delete all the campaign references in the TLOs.
+        This will override the delete_detail in the core API.
+
+        The campaign ID must be part of the URL (/api/v1/campaigns/{id}/)
+
+        :param request: The incoming request.
+        :type request: :class:`django.http.HttpRequest`
+        :returns: HttpResponse.
+        """
+        content = {'return_code': 1,
+                   'type': 'Campaign'}
+
+        analyst = request.user.username
+        if not is_admin(analyst):
+          content['message'] = 'You must be an admin to delete campaigns.'
+          self.crits_response(content)
+
+        path = request.path
+        parts = path.split("/")
+        id = parts[(len(parts) - 2)]
+
+        if not ObjectId.is_valid(id):
+          content['message'] = 'You must provide a valid campaign ID.'
+          self.crits_response(content)
+
+        campaign = Campaign.objects(id=id).first()
+        sources = user_sources(analyst)
+ 
+        # Remove associations
+        formatted_query = {'campaign.name': campaign.name}
+        for obj_type in [Domain, PCAP, Indicator, Email, Sample, IP, Event, RawData, Actor]:
+           
+          objects = obj_type.objects(source__name__in=sources, __raw__=formatted_query)
+          for obj in objects:
+            result = campaign_remove(obj._meta['crits_type'],obj.id,campaign.name,analyst)
+
+        result = remove_campaign(campaign.name, analyst)
+
+        if result['success']:
+          content['return_code'] = 0
+        else:
+          content['message'] = result['message']
         self.crits_response(content)

--- a/crits/core/class_mapper.py
+++ b/crits/core/class_mapper.py
@@ -298,3 +298,67 @@ def class_from_type(type_):
         return UserRole
     else:
         return None
+
+
+def class_from_path_name(path):
+    """
+    Return a class object based on the path name from the URL.
+
+    :param type_: The CRITs top-level object type.
+    :type type_: str
+    :param value: The value to search for.
+    :type value: str
+    :returns: class which inherits from
+              :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
+    """
+
+    # doing this to avoid circular imports
+    from crits.actors.actor import Actor
+    from crits.campaigns.campaign import Campaign
+    from crits.certificates.certificate import Certificate
+    from crits.comments.comment import Comment
+    from crits.domains.domain import Domain
+    from crits.emails.email import Email
+    from crits.events.event import Event
+    from crits.indicators.indicator import Indicator
+    from crits.ips.ip import IP
+    from crits.pcaps.pcap import PCAP
+    from crits.raw_data.raw_data import RawData
+    from crits.samples.sample import Sample
+    from crits.screenshots.screenshot import Screenshot
+    from crits.targets.target import Target
+
+    # Make sure value is a string...
+    value = str(path)
+
+    if path == 'ips':
+      return IP
+    elif path == 'domains':
+      return Domain
+    elif path == 'samples':
+      return Sample
+    elif path == 'campaigns':
+      return Campaign
+    elif path == 'pcaps':
+      return PCAP
+    elif path == 'emails':
+      return Email
+    elif path == 'comments':
+      return Comment
+    elif path == 'actors':
+      return Actor
+    elif path == 'certificates':
+      return Certificate
+    elif path == 'events':
+      return Event
+    elif path == 'raw_data':
+      return RawData
+    elif path == 'screenshots':
+      return Screenshot
+    elif path == 'targets':
+      return Target
+    elif path == 'indicators':
+      return Indicator
+    else:
+      return None
+

--- a/crits/domains/api.py
+++ b/crits/domains/api.py
@@ -17,7 +17,7 @@ class DomainResource(CRITsAPIResource):
 
     class Meta:
         object_class = Domain
-        allowed_methods = ('get', 'post')
+        allowed_methods = ('get', 'post', 'delete')
         resource_name = "domains"
         authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
                                              CRITsSessionAuthentication())

--- a/crits/ips/api.py
+++ b/crits/ips/api.py
@@ -18,7 +18,7 @@ class IPResource(CRITsAPIResource):
 
     class Meta:
         object_class = IP
-        allowed_methods = ('get', 'post')
+        allowed_methods = ('get', 'post', 'delete')
         resource_name = "ips"
         authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
                                              CRITsSessionAuthentication())

--- a/crits/pcaps/api.py
+++ b/crits/pcaps/api.py
@@ -18,7 +18,7 @@ class PCAPResource(CRITsAPIResource):
 
     class Meta:
         object_class = PCAP
-        allowed_methods = ('get', 'post')
+        allowed_methods = ('get', 'post', 'delete')
         resource_name = "pcaps"
         authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
                                              CRITsSessionAuthentication())

--- a/crits/samples/api.py
+++ b/crits/samples/api.py
@@ -18,7 +18,7 @@ class SampleResource(CRITsAPIResource):
 
     class Meta:
         object_class = Sample
-        allowed_methods = ('get', 'post')
+        allowed_methods = ('get', 'post', 'delete')
         resource_name = "samples"
         authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
                                              CRITsSessionAuthentication())


### PR DESCRIPTION
I am creating a new branch and pull request focused solely on deleting top level objects. Based on the discussion around #333 and #383, I think it will be easier if we separate the discussion and code for the DELETE calls from the discussion and code for the POST/PATCH calls.

This code is not yet complete. I would like the design to be reviewed before finalizing it. In this design, deletion for any TLO can be handled by the core api.py. The core api.py file uses the core handler.py to delete the object. The handler.py has been modified so that the same deletion code can be used for web requests and API requests. Even though the core api.py has code to delete any TLO, you can't delete a specific TLO type until 'delete' is added to the list of allowed methods within that TLO's api.py file. If a particular TLO needs special handling, as is the case with campaigns, then that TLO's api.py file can override the core code with it's own implementation. This should allow for the code to be centralized, allow for individual delete permissions for each TLO, and allow a TLO to override the default deletion code when customized actions are needed.

Let me know if this is closer to what you had in mind and if you have any feedback for improvements.