### PR TITLE
Use 'Contains' relationship when adding Email attachment

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -1127,7 +1127,10 @@ def handle_file(filename, data, source, method='Generic', reference=None, relate
         if related_obj and sample:
             if related_obj.id != sample.id: #don't form relationship to itself
                 if not relationship:
-                    relationship = "Related_To"
+                    if related_obj._meta['crits_type'] == 'Email':
+                        relationship = "Contained_Within"
+                    else:
+                        relationship = "Related_To"
                 sample.add_relationship(rel_item=related_obj,
                                         rel_type=relationship,
                                         analyst=user,


### PR DESCRIPTION
When adding an Email to CRITs via a .eml or .msg file, any attachments are related to the Email TLO using a Contains/Contained_Within relationship, however using the "Add Attachment" button for an existing Email only formed the more generic "Related_To" relationship.

This change will make email attachments more consistent by using a Contains/Contained_Within relationship when adding attachments to an existing Email.