### PR TITLE
Enable Cross Site Request Forgery (CSRF) protection.

### DIFF
--- a/crits/core/static/js/core.js
+++ b/crits/core/static/js/core.js
@@ -646,6 +646,19 @@ function initTabNav() {
     });
 }
 
+var csrftoken = readCookie('csrftoken');
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+$.ajaxSetup({
+    // Set request header for ajax POST
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+        }
+    }
+});
 
 $(document).ready(function() {
     var src_filter = '[name!="analyst"]';

--- a/crits/core/static/js/dialogs.js
+++ b/crits/core/static/js/dialogs.js
@@ -119,6 +119,8 @@ function delete_object_click(e, item_type, del_label, data) {
     var fn = (function(e) {
         return function() {
         var form = "<form method='POST' action='" + action + "'>";
+        var csrftoken = readCookie('csrftoken');
+        form = form + "<input type='hidden' name='csrfmiddlewaretoken' value='" + csrftoken + "'>"
         $.each(data, function(k,v) { form = form + $("input").attr("type","hidden").attr("name",k).val(v).html(); } );
         form = form + "</form>";
         $(form).appendTo("body").submit();
@@ -443,7 +445,11 @@ function preference_toggle(e) {
 function defaultSubmit(e) {
     var dialog = $(e.currentTarget).closest(".ui-dialog").find(".ui-dialog-content");
     var form = dialog.find('form');
-
+    var csrftoken = readCookie('csrftoken');
+    var input = $("<input>")
+               .attr("type", "hidden")
+               .attr("name", "csrfmiddlewaretoken").val(csrftoken);
+    form.append($(input));
     form.submit();
 }
 

--- a/crits/screenshots/static/js/screenshots.js
+++ b/crits/screenshots/static/js/screenshots.js
@@ -49,7 +49,11 @@ function add_screenshot_submit(e) {
     var elem = $(e.currentTarget);
     var dialog = elem.closest(".ui-dialog");
     var form = dialog.find("form");
-
+    var csrftoken = readCookie('csrftoken');
+    var input = $("<input>")
+               .attr("type", "hidden")
+               .attr("name", "csrfmiddlewaretoken").val(csrftoken);
+    form.append($(input));
     form.find("#id_oid").val(my_id);
     form.find("#id_otype").val(my_type);
     form.submit();

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -290,6 +290,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/crits/targets/templates/target.html
+++ b/crits/targets/templates/target.html
@@ -136,7 +136,7 @@
 
 <div style="display: none;">
     <div id="edit-details-form" title="Edit Details" style="display: table;">
-        <form id="form-edit-details" action='{% url 'crits.targets.views.add_update_target' %}' method='POST' style="display: inline;">
+        <form id="form-edit-details" action='{% url 'crits.targets.views.add_update_target' %}' method='POST' style="display: inline;">{% csrf_token %}
         <table class='form'> {{ form.as_table }}</table>
         </form>
     </div>

--- a/extras/www/static/js/core.js
+++ b/extras/www/static/js/core.js
@@ -646,6 +646,19 @@ function initTabNav() {
     });
 }
 
+var csrftoken = readCookie('csrftoken');
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+$.ajaxSetup({
+    // Set request header for ajax POST
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+        }
+    }
+});
 
 $(document).ready(function() {
     var src_filter = '[name!="analyst"]';

--- a/extras/www/static/js/dialogs.js
+++ b/extras/www/static/js/dialogs.js
@@ -119,6 +119,8 @@ function delete_object_click(e, item_type, del_label, data) {
     var fn = (function(e) {
         return function() {
         var form = "<form method='POST' action='" + action + "'>";
+        var csrftoken = readCookie('csrftoken');
+        form = form + "<input type='hidden' name='csrfmiddlewaretoken' value='" + csrftoken + "'>"
         $.each(data, function(k,v) { form = form + $("input").attr("type","hidden").attr("name",k).val(v).html(); } );
         form = form + "</form>";
         $(form).appendTo("body").submit();
@@ -443,7 +445,11 @@ function preference_toggle(e) {
 function defaultSubmit(e) {
     var dialog = $(e.currentTarget).closest(".ui-dialog").find(".ui-dialog-content");
     var form = dialog.find('form');
-
+    var csrftoken = readCookie('csrftoken');
+    var input = $("<input>")
+               .attr("type", "hidden")
+               .attr("name", "csrfmiddlewaretoken").val(csrftoken);
+    form.append($(input));
     form.submit();
 }
 

--- a/extras/www/static/js/screenshots.js
+++ b/extras/www/static/js/screenshots.js
@@ -49,7 +49,11 @@ function add_screenshot_submit(e) {
     var elem = $(e.currentTarget);
     var dialog = elem.closest(".ui-dialog");
     var form = dialog.find("form");
-
+    var csrftoken = readCookie('csrftoken');
+    var input = $("<input>")
+               .attr("type", "hidden")
+               .attr("name", "csrfmiddlewaretoken").val(csrftoken);
+    form.append($(input));
     form.find("#id_oid").val(my_id);
     form.find("#id_otype").val(my_type);
     form.submit();


### PR DESCRIPTION
This change enables Cross Site Request Forgery (CSRF) protection.
https://docs.djangoproject.com/en/1.6/ref/contrib/csrf/

Enable django middleware in settings.py:
'django.middleware.csrf.CsrfViewMiddleware'

Template forms get {% csrf token %} where required.

AJAX forms get csrf token added to the header in $.ajaxSetup()
                Read the cookie
                Add token to header
                
Non-AJAX forms are handled individually as I tested.
                Read the cookie
                Add token as hidden input in the form
                
Dynamic javascript forms
                Read the cookie
                Add hidden input as string before form is appended to the body
