### PR TITLE
Improve Target Visibility and Handling

### DIFF
--- a/crits/campaigns/handlers.py
+++ b/crits/campaigns/handlers.py
@@ -26,6 +26,7 @@ from crits.indicators.indicator import Indicator
 from crits.ips.ip import IP
 from crits.pcaps.pcap import PCAP
 from crits.samples.sample import Sample
+from crits.targets.handlers import get_campaign_targets
 from crits.targets.target import Target
 
 
@@ -92,19 +93,7 @@ def get_campaign_details(campaign_name, analyst):
                                                               __raw__=formatted_query).count()
 
     # Item counts for targets
-    emails = Email.objects(source__name__in=sources, __raw__=formatted_query)
-    addresses = {}
-    for email in emails:
-        for to in email['to']:
-            # This might be a slow operation since we're looking up all "to"
-            # targets, could possibly bulk search this.
-            target = Target.objects(email_address__iexact=to).first()
-
-            if target is not None:
-                addresses[target.email_address] = 1
-            else:
-                addresses[to] = 1
-    uniq_addrs = addresses.keys()
+    uniq_addrs = get_campaign_targets(campaign_name, analyst)
     counts['Target'] = Target.objects(email_address__in=uniq_addrs).count()
 
     # favorites

--- a/crits/core/class_mapper.py
+++ b/crits/core/class_mapper.py
@@ -202,7 +202,11 @@ def class_from_value(type_, value):
     elif type_ == 'Screenshot':
         return Screenshot.objects(id=value).first()
     elif type_ == 'Target':
-        return Target.objects(email_address__iexact=value).first()
+        target = Target.objects(email_address=value).first()
+        if target:
+            return target
+        else:
+            return Target.objects(email_address__iexact=value).first()
     else:
         return None
 

--- a/crits/core/form_consts.py
+++ b/crits/core/form_consts.py
@@ -1,6 +1,8 @@
 class Common():
     ADD_INDICATOR = "Add Indicator?"
     BUCKET_LIST = "Bucket List"
+    CAMPAIGN = "Campaign"
+    CAMPAIGN_CONFIDENCE = "Campaign Confidence"
     OBJECTS_DATA = "Objects Data"
     SOURCE = "Source"
     SOURCE_REFERENCE = "Source Reference"
@@ -49,8 +51,8 @@ class Actor():
     NAME = "Name"
     ALIASES = "Aliases"
     DESCRIPTION = "Description"
-    CAMPAIGN = "Campaign"
-    CAMPAIGN_CONFIDENCE = "Campaign Confidence"
+    CAMPAIGN = Common.CAMPAIGN
+    CAMPAIGN_CONFIDENCE = Common.CAMPAIGN_CONFIDENCE
     SOURCE = Common.SOURCE
     SOURCE_METHOD = "Source Method"
     SOURCE_REFERENCE = Common.SOURCE_REFERENCE
@@ -82,8 +84,8 @@ class IP():
     IP_ADDRESS = "IP Address"
     IP_TYPE = "IP Type"
     ANALYST = "Analyst"
-    CAMPAIGN = "Campaign"
-    CAMPAIGN_CONFIDENCE = "Campaign Confidence"
+    CAMPAIGN = Common.CAMPAIGN
+    CAMPAIGN_CONFIDENCE = Common.CAMPAIGN_CONFIDENCE
     SOURCE = Common.SOURCE
     SOURCE_METHOD = Common.SOURCE_METHOD
     SOURCE_REFERENCE = Common.SOURCE_REFERENCE
@@ -103,8 +105,8 @@ class Domain():
     """
 
     DOMAIN_NAME = "Domain Name"
-    CAMPAIGN = "Campaign"
-    CAMPAIGN_CONFIDENCE = "Campaign Confidence"
+    CAMPAIGN = Common.CAMPAIGN
+    CAMPAIGN_CONFIDENCE = Common.CAMPAIGN_CONFIDENCE
     DOMAIN_SOURCE = Common.SOURCE
     DOMAIN_METHOD = Common.SOURCE_METHOD
     DOMAIN_REFERENCE = Common.SOURCE_REFERENCE
@@ -210,8 +212,8 @@ class Sample():
     """
 
     BUCKET_LIST = Common.BUCKET_LIST
-    CAMPAIGN = "Campaign"
-    CAMPAIGN_CONFIDENCE = "Campaign Confidence"
+    CAMPAIGN = Common.CAMPAIGN
+    CAMPAIGN_CONFIDENCE = Common.CAMPAIGN_CONFIDENCE
     EMAIL_RESULTS = "Email Me Results"
     FILE_DATA = "File Data"
     FILE_FORMAT = "File Format"
@@ -239,6 +241,9 @@ class Target():
     """
 
     TITLE = "Title"
+    CAMPAIGN = Common.CAMPAIGN
+    CAMPAIGN_CONFIDENCE = Common.CAMPAIGN_CONFIDENCE
+
 
 
 def get_source_field_for_class(otype):

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1535,6 +1535,12 @@ def gen_global_query(obj,user,term,search_type="global",force_full=False):
                     {'description': search_query},
                     {'tags': search_query},
                 ]
+        elif type_ == "Target":
+            search_list = [
+                    {'email_address': search_query},
+                    {'firstname': search_query},
+                    {'lastname': search_query},
+                ]
         else:
             search_list = [{'name': search_query}]
         search_list.append({'source.instances.reference':search_query})

--- a/crits/core/static/js/dialogs.js
+++ b/crits/core/static/js/dialogs.js
@@ -1019,6 +1019,18 @@ function new_sample_dialog() {
     }
 }
 
+function new_target_dialog() {
+    var element = document.getElementById('id_campaign');
+    var className = $(this).dialog("activatedBy")[0].className
+    if (className === "ui-icon ui-icon-plusthick add dialogClick") {
+        var campaign = this.baseURI.match(/\/campaigns\/details\/(.*)\//);
+        element.value = decodeURI(campaign[1]);
+    }
+    else {
+        element.value = '';
+    }
+}
+
 /// Standard Dialog setup below
 
 var stdDialogs = {
@@ -1041,7 +1053,7 @@ var stdDialogs = {
       "new-raw-data": {title: "Raw Data" },
       "raw_data_type_add": {title: "Raw Data Type"},
 
-      "new-target": {title: "Target"},
+      "new-target": {title: "Target", open: new_target_dialog },
 
       "backdoor_add": {title: "Backdoor"},
       "exploit_add": {title: "Exploit"},

--- a/crits/stats/handlers.py
+++ b/crits/stats/handlers.py
@@ -273,12 +273,14 @@ def target_user_stats():
     results = Email.objects(to__exists=True).map_reduce(m, r, 'inline')
     for result in results:
         try:
-            targ = Target.objects(email_address__iexact=result.key).first()
-            if not targ:
-                targ = Target()
-                targ.email_address = result.key
-            targ.email_count = result.value['count']
-            targ.save()
+            targs = Target.objects(email_address__iexact=result.key)
+            if not targs:
+                targs = [Target()]
+                targs[0].email_address = result.key.strip().lower()
+
+            for targ in targs:
+                targ.email_count = result.value['count']
+                targ.save()
         except:
             pass
     mapcode = """

--- a/crits/targets/forms.py
+++ b/crits/targets/forms.py
@@ -1,6 +1,10 @@
 from django import forms
+from django.forms.util import ErrorList
 
+from crits.campaigns.campaign import Campaign
+from crits.core import form_consts
 from crits.core.forms import add_bucketlist_to_form, add_ticket_to_form
+from crits.core.handlers import get_item_names
 
 class TargetInfoForm(forms.Form):
     """
@@ -25,8 +29,34 @@ class TargetInfoForm(forms.Form):
                             required=False)
     note = forms.CharField(widget=forms.Textarea(attrs={'cols':'50', 'rows':'2'}),
                            required=False)
+    campaign = forms.ChoiceField(widget=forms.Select, required=False,
+                                 label=form_consts.Target.CAMPAIGN)
+    camp_conf = forms.ChoiceField(required=False,
+                                  label=form_consts.Target.CAMPAIGN_CONFIDENCE)
 
     def __init__(self, *args, **kwargs):
         super(TargetInfoForm, self).__init__(*args, **kwargs)
+        campaigns = [('', '')] + [(c.name,
+                                   c.name) for c in get_item_names(Campaign,
+                                                                   True)]
+        self.fields['campaign'].choices = campaigns
+        self.fields['camp_conf'].choices = [('',''),
+                                            ('low', 'low'),
+                                            ('medium', 'medium'),
+                                            ('high', 'high')]
+
         add_bucketlist_to_form(self)
         add_ticket_to_form(self)
+
+    def clean(self):
+        cleaned_data = super(TargetInfoForm, self).clean()
+        campaign = cleaned_data.get('campaign')
+
+        if campaign:
+            confidence = cleaned_data.get('camp_conf')
+
+            if not confidence or confidence == '':
+                self._errors.setdefault('camp_conf', ErrorList())
+                self._errors['camp_conf'].append(u'This field is required if campaign is specified.')
+
+        return cleaned_data

--- a/crits/targets/handlers.py
+++ b/crits/targets/handlers.py
@@ -7,7 +7,7 @@ from django.template import RequestContext
 from mongoengine.base import ValidationError
 
 from crits.core import form_consts
-from crits.core.crits_mongoengine import json_handler
+from crits.core.crits_mongoengine import json_handler, EmbeddedCampaign
 from crits.core.handlers import jtable_ajax_list, build_jtable, jtable_ajax_delete
 from crits.core.handlers import csv_export
 from crits.core.user_tools import is_user_subscribed, user_sources
@@ -69,6 +69,10 @@ def upsert_target(data, analyst):
         target.note = data['note']
     if 'title' in data:
         target.title = data['title']
+    if 'campaign' in data and 'camp_conf' in data:
+        target.add_campaign(EmbeddedCampaign(name=data['campaign'],
+                                             confidence=data['camp_conf'],
+                                             analyst=analyst))
     if 'bucket_list' in data:
         bucket_list = data.get(form_consts.Common.BUCKET_LIST_VARIABLE_NAME)
     if 'ticket' in data:
@@ -212,7 +216,7 @@ def get_target_details(email_address, analyst):
 
     return template, args
 
-def get_campaign_targets(campaign,user):
+def get_campaign_targets(campaign, user):
     """
     Get targets related to a specific campaign.
 

--- a/crits/targets/handlers.py
+++ b/crits/targets/handlers.py
@@ -46,12 +46,17 @@ def upsert_target(data, analyst):
     if 'email_address' not in data:
         return {'success': False,
                 'message': "No email address to look up"}
-    target = Target.objects(email_address__iexact=data['email_address']).first()
+
+    # check for exact match first
+    target = Target.objects(email_address=data['email_address']).first()
+
+    if not target: # if no exact match, look for case-insensitive match
+        target = Target.objects(email_address__iexact=data['email_address']).first()
     is_new = False
     if not target:
         is_new = True
         target = Target()
-        target.email_address = data['email_address']
+        target.email_address = data['email_address'].strip().lower()
 
     bucket_list = False
     ticket = False
@@ -110,27 +115,13 @@ def remove_target(email_address=None, analyst=None):
     if not email_address:
         return {'success': False,
                 'message': "No email address to look up"}
-    target = Target.objects(email_address__iexact=email_address).first()
+    target = Target.objects(email_address=email_address).first()
     if not target:
         return {'success': False,
                 'message': "No target matching this email address."}
     target.delete(username=analyst)
     return {'success': True,
             'message': "Target removed successfully"}
-
-def get_target(email_address=None):
-    """
-    Get a target from the database.
-
-    :param email_address: The email address of the target to get.
-    :type email_address: str
-    :returns: None, :class:`crits.targets.target.Target`
-    """
-
-    if not email_address:
-        return None
-    target = Target.objects(email_address__iexact=email_address).first()
-    return target
 
 def get_target_details(email_address, analyst):
     """
@@ -148,14 +139,17 @@ def get_target_details(email_address, analyst):
         template = "error.html"
         args = {'error': "Must provide an email address."}
         return template, args
-    target = Target.objects(email_address__iexact=email_address).first()
+
+    # check for exact match first
+    target = Target.objects(email_address=email_address).first()
+
+    if not target: # if no exact match, look for case-insensitive match
+        target = Target.objects(email_address__iexact=email_address).first()
     if not target:
         target = Target()
-        target.email_address = email_address
+        target.email_address = email_address.strip().lower()
         form = TargetInfoForm(initial={'email_address': email_address})
     email_list = target.find_emails(analyst)
-    #initial_data = target.to_dict()
-    #initial_data['bucket_list'] = target.get_bucket_list_string();
     form = TargetInfoForm(initial=target.to_dict())
 
     if form.fields.get(form_consts.Common.BUCKET_LIST_VARIABLE_NAME) != None:
@@ -236,15 +230,8 @@ def get_campaign_targets(campaign, user):
     addresses = {}
     for email in emails:
         for to in email['to']:
-
-            # This might be a slow operation since we're looking up all "to"
-            # targets, could possibly bulk search this.
-            target = Target.objects(email_address__iexact=to).first()
-
-            if target is not None:
-                addresses[target.email_address] = 1
-            else:
-                addresses[to] = 1
+            addresses[to.strip().lower()] = 1 # add the way it should be
+            addresses[to] = 1 # also add the way it is in the Email
 
     # Get addresses of Targets attributed to this campaign
     targets = Target.objects(campaign__name=campaign).only('email_address')

--- a/crits/targets/handlers.py
+++ b/crits/targets/handlers.py
@@ -229,6 +229,8 @@ def get_campaign_targets(campaign, user):
 
     # Searching for campaign targets
     sourcefilt = user_sources(user)
+
+    # Get addresses from the 'to' field of emails attributed to this campaign
     emails = Email.objects(source__name__in=sourcefilt,
                            campaign__name=campaign).only('to')
     addresses = {}
@@ -243,6 +245,12 @@ def get_campaign_targets(campaign, user):
                 addresses[target.email_address] = 1
             else:
                 addresses[to] = 1
+
+    # Get addresses of Targets attributed to this campaign
+    targets = Target.objects(campaign__name=campaign).only('email_address')
+    for target in targets:
+        addresses[target.email_address] = 1
+
     uniq_addrs = addresses.keys()
     return uniq_addrs
 

--- a/crits/targets/views.py
+++ b/crits/targets/views.py
@@ -7,10 +7,11 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
+from crits.core.class_mapper import class_from_value
 from crits.core.user_tools import user_can_view_data, user_is_admin
 from crits.targets.forms import TargetInfoForm
 from crits.targets.handlers import upsert_target, get_target_details
-from crits.targets.handlers import remove_target, get_target
+from crits.targets.handlers import remove_target
 from crits.targets.handlers import generate_target_jtable, generate_target_csv
 from crits.targets.handlers import generate_division_jtable
 
@@ -89,7 +90,8 @@ def add_update_target(request):
     """
 
     if request.method == "POST":
-        email = request.POST['email_address'].strip()
+        email = request.POST['email_address']
+        new_email = email.strip().lower()
         form = TargetInfoForm(request.POST)
         analyst = request.user.username
         if form.is_valid():
@@ -98,8 +100,8 @@ def add_update_target(request):
             if results['success']:
                 message = '<div>Click here to view the new target: <a href='
                 message += '"%s">%s</a></div>' % (reverse('crits.targets.views.target_info',
-                                                        args=[email]),
-                                                  email)
+                                                          args=[new_email]),
+                                                  new_email)
                 result = {'message': message}
             else:
                 result = results
@@ -158,11 +160,11 @@ def target_details(request, email_address=None):
     if email_address is None:
         form = TargetInfoForm()
     else:
-        target = get_target(email_address)
+        target = class_from_value('Target', email_address)
         if not target:
             form = TargetInfoForm(initial={'email_address': email_address})
         else:
-            form = TargetInfoForm(initial=target)
+            form = TargetInfoForm(initial=target.to_dict())
     return render_to_response('target_form.html',
                               {'form': form},
                               RequestContext(request))

--- a/extras/www/static/js/dialogs.js
+++ b/extras/www/static/js/dialogs.js
@@ -1019,6 +1019,18 @@ function new_sample_dialog() {
     }
 }
 
+function new_target_dialog() {
+    var element = document.getElementById('id_campaign');
+    var className = $(this).dialog("activatedBy")[0].className
+    if (className === "ui-icon ui-icon-plusthick add dialogClick") {
+        var campaign = this.baseURI.match(/\/campaigns\/details\/(.*)\//);
+        element.value = decodeURI(campaign[1]);
+    }
+    else {
+        element.value = '';
+    }
+}
+
 /// Standard Dialog setup below
 
 var stdDialogs = {
@@ -1041,7 +1053,7 @@ var stdDialogs = {
       "new-raw-data": {title: "Raw Data" },
       "raw_data_type_add": {title: "Raw Data Type"},
 
-      "new-target": {title: "Target"},
+      "new-target": {title: "Target", open: new_target_dialog },
 
       "backdoor_add": {title: "Backdoor"},
       "exploit_add": {title: "Exploit"},


### PR DESCRIPTION
I was seeing a variety of problems when the same email address, but with different case, exists in multiple Targets.  Ideally we could consider email addresses case-insensitive and an address would only appear once in the Targets collection. While the Email TLO would retain record of how the address was actually cased, the Targets collection would consist of only lower-cased email addresses. However, this is not necessarily the case.

I made a few changes to **Targets** to address that and a couple other issues:
* Adding/Updating:
  * Problem: Using “iexact” in upsert_target was sometimes causing the wrong Target to be updated. If a user updates a Target, but the same email address with different case also exists as a Target, the other Target may be updated instead.
  * Fix: Now the code will first look for an exact match, if none is found it will look for a case-insensitive match (to avoid creating a case-insensitive duplicate). If still none is found, a Target will be created with a lower-case version of the email address.

* Deleting
  * Problem: Due to the use of “iexact”, sometimes the wrong Target would be deleted.
  * Fix: Only an exact match is deleted.

* Details
  * Problem: Using “iexact” here makes it so the user may not be able to access the Target they intend to view.
  * Fix: When requesting a Target details page, because the email address is used as the unique identifier, do the following:
    * First look for an exact email address match
    * If an exact match isn’t found, find a case-insensitive match.
    * If a match still is not found, use the lower-case version of the email address.
    * Emails tab and count uses a case insensitive query

* Adding to Campaign
  * Change: If the user is viewing Campaign Details and clicks the “Add Target” button at the top of the Targets jtable, the form will automatically select the current Campaign.
  * **Note**: I’m pretty sure there is a better way to do the javascript for this, so I’m open to suggestions. :)

* Listing in Campaign
  * The jtable in the Campaign's "Targets" tab will include:
	* Every campaign-attributed Target (Fixes #443)
	* Every Target with an email address matching an exact, or lower-cased, address within the “To” line of an attributed Email.
		* The “correct” Target will contain the lower-cased version of the email address.
		* The exact email address is included so that the user is made aware of old or duplicate Targets that weren’t lower-cased.
		* I would have liked to do a case-insensitve query here so that the user would be made aware of any duplicate Target, but I didn't for performance reasons.
  * Email Count uses a case insensitive query. Differently cased version of the same email address will have the same count.

**Note**: I realize some of this will be affected by the potential upcoming Campaign changes (#446), but since that might not happen for awhile, I thought it would be good to address these things now.


