### PR TITLE
Add CSRF token to login page for first-time users

### DIFF
--- a/crits/core/templates/login.html
+++ b/crits/core/templates/login.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
+{% csrf_token %}
 
 <script>
     var reset_password = "{% url 'crits.core.views.reset_password' %}";


### PR DESCRIPTION
Need a cookie to use the ajax CSRF method, need the ajax CSRF method to work to log in, need to log in to get the cookie. Resolved this catch-22 by injecting the token into the login page. Fixes #467