### PR TITLE
Bootstrap: Check for the database configuration file and fix for sed

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -106,7 +106,7 @@ if [ ! -f crits/config/database.py ]; then
   cp crits/config/database_example.py crits/config/database.py
   SC="$(python contrib/gen_secret_key.py)"
   # This is going to escape the '&' character that is a special character in sed 
-  SE=${SC//\&/\\&}
+  SE=$(echo ${SC} | sed -e 's/&/\\\&/g')
   sed -i -e "s/^\(SECRET_KEY = \).*$/\1\'${SE}\'/1" crits/config/database.py
 else
   echo "Database configuration file exists, skip secret_key generation!"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -101,11 +101,16 @@ echo "Setting up crits.log file"
 touch logs/crits.log
 chmod 664 logs/crits.log
 
-echo "Creating default database configuration file"
-cp crits/config/database_example.py crits/config/database.py
-SC="$(python contrib/gen_secret_key.py)"
-sed -i '' -e "s/.*SECRET_KEY.*/SECRET_KEY = \'"$SC"\'/" crits/config/database.py
-
+if [ ! -f crits/config/database.py ]; then
+  echo "Creating default database configuration file"
+  cp crits/config/database_example.py crits/config/database.py
+  SC="$(python contrib/gen_secret_key.py)"
+  # This is going to escape the '&' character that is a special character in sed 
+  SE=${SC//\&/\\&}
+  sed -i -e "s/^\(SECRET_KEY = \).*$/\1\'${SE}\'/1" crits/config/database.py
+else
+  echo "Database configuration file exists, skip secret_key generation!"
+fi
 # If MongoDB isn't already running, ask to start it.
 # This can fail if MongoDB is running already but on a non-standard port.
 pgrep mongod >/dev/null 2>&1


### PR DESCRIPTION
If database file exists already, it means that the bootstrap has been run before. In such case skip the secret key generation because it might break things.
Additionally, ampersand needs to be escaped in the variable that  contains the generated secret key or sed will badly mangle the key.

Just set the SC to something like that: 
`SC='test&test'`
 and run
`sed -i '' -e "s/.*SECRET_KEY.*/SECRET_KEY = \'"$SC"\'/" crits/config/database.py`

also ...
-i '' causes the sed to error our, so leaving it as -i is better. 
I also reworked the regex to a nicer form.
