### PR TITLE
update to fix the pip requirement woes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ django-tastypie-mongoengine==0.4.5
 kombu
 lxml
 m2crypto
---allow-external mongoengine mongoengine==0.8.7
+--allow-external mongoengine
+mongoengine==0.8.7
 pydeep==0.2
 pydot
 pymongo==2.7.2


### PR DESCRIPTION
According to the pip documentation, "--allow-external mongoengine" should be listed on a separate line.
Please see... https://pip.pypa.io/en/stable/reference/pip_install.html#externally-hosted-files

This also fixes the whole thing for Ubuntu 14.04 install.