### PR TITLE
Fix the path for crits.log

### DIFF
--- a/crits/config/config.py
+++ b/crits/config/config.py
@@ -50,7 +50,7 @@ class CRITsConfig(CritsDocument, Document):
     ldap_usercn = StringField(default='')
     ldap_userdn = StringField(default='')
     ldap_update_on_login = BooleanField(default=False)
-    log_directory = StringField(default=os.path.join(settings.SITE_ROOT, 'logs'))
+    log_directory = StringField(default=os.path.join(settings.SITE_ROOT, '..', 'logs'))
     log_level = StringField(default='INFO')
     password_complexity_desc = StringField(default='8 characters, at least 1 capital, 1 lowercase and 1 number/special')
     password_complexity_regex = StringField(default='(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$')


### PR DESCRIPTION
The path was one level too high
 "/data/crits/crits/logs/cirts.log"
The change makes it what it should be:
"/data/crits/logs/cirts.log"