### PR TITLE
Sharing String Indicators and Relationships via STIX

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -3,6 +3,17 @@ should be aware of. This will also include things like dependency changes or
 references to changes in other repositories. Updates are sorted by commit date
 descending.
 
+Author: brlogan
+Date: 2015-05-07
+
+    Added support for sharing String Indicators via STIX. Because there is no
+    generic String type in CybOX, the CybOX Custom object must be used. This
+    requries updating python-stix and python-cybox.
+    
+    Updated versions are:
+        cybox-2.1.0.11
+        stix-1.1.1.5
+
 Author: mgoffin
 Date:   2015-04-28
 

--- a/crits/emails/email.py
+++ b/crits/emails/email.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from cybox.common import String, DateTime
 from cybox.core import Observable
 from cybox.objects.address_object import Address, EmailAddress
-from cybox.objects.email_message_object import EmailHeader, EmailMessage
+from cybox.objects.email_message_object import EmailHeader, EmailMessage, Attachments
 
 from crits.core.crits_mongoengine import CritsBaseAttributes, CritsSourceDocument
 from crits.core.fields import CritsDateTimeField
@@ -211,6 +211,8 @@ class Email(CritsBaseAttributes, CritsSourceDocument, Document):
             obj.header.from_ = EmailAddress(self.from_address)
         if 'date' not in exclude and 'isodate' not in exclude:
             obj.header.date = DateTime(self.isodate)
+
+	obj.attachments = Attachments()
 
         observables.append(Observable(obj))
         return (observables, self.releasability)

--- a/crits/events/event.py
+++ b/crits/events/event.py
@@ -90,6 +90,18 @@ class Event(CritsBaseAttributes, CritsSourceDocument, Document):
     def stix_title(self):
         return self.title
 
+    def to_stix_incident(self):
+        """
+        Creates a STIX Incident object from a CRITs Event.
+
+        Returns the STIX Incident and the original CRITs Event's
+        releasability list.
+        """
+        from stix.incident import Incident
+        inc = Incident(title=self.title, description=self.description)
+
+        return (inc, self.releasability)
+
     @classmethod
     def from_stix(cls, stix_package):
         """

--- a/crits/objects/object_mapper.py
+++ b/crits/objects/object_mapper.py
@@ -341,7 +341,7 @@ def make_crits_object(cybox_obj):
         return o
     elif isinstance(cybox_obj, Artifact):
         o.object_type = "Artifact"
-        o.value = get_object_values(cybox_obj.data)
+        o.value = [cybox_obj.data]
         if cybox_obj.type_ == Artifact.TYPE_GENERIC:
             o.name = "Data Region"
             return o

--- a/crits/objects/object_mapper.py
+++ b/crits/objects/object_mapper.py
@@ -1,12 +1,14 @@
 from crits.core.crits_mongoengine import EmbeddedObject
 
 from cybox.common import String, PositiveInteger, StructuredText
+from cybox.common.object_properties import CustomProperties, Property
 
 from cybox.objects.account_object import Account
 from cybox.objects.address_object import Address
 from cybox.objects.api_object import API
 from cybox.objects.artifact_object import Artifact
 from cybox.objects.code_object import Code
+from cybox.objects.custom_object import Custom
 from cybox.objects.disk_object import Disk
 from cybox.objects.disk_partition_object import DiskPartition
 from cybox.objects.domain_name_object import DomainName
@@ -190,7 +192,18 @@ def make_cybox_object(type_, name=None, value=None):
         p.name = String(value)
         return p
     elif type_ == "String":
-        return String(value)
+        c = Custom()
+        c.custom_name = "crits:String"
+        c.description = ("This is a generic string used as the value of an "
+                         "Indicator or Object within CRITs.")
+        c.custom_properties = CustomProperties()
+
+        p1 = Property()
+        p1.name = "value"
+        p1.description = "Generic String"
+        p1.value = value
+        c.custom_properties.append(p1)
+        return c
     elif type_ == "System":
         s = System()
         s.hostname = String(value)
@@ -356,6 +369,12 @@ def make_crits_object(cybox_obj):
         o.name = str(cybox_obj.type)
         o.value = get_object_values(cybox_obj.code_segment)
         return o
+    elif isinstance(cybox_obj, Custom):
+        if cybox_obj.custom_name == "crits:String":
+            if cybox_obj.custom_properties[0].name == "value":
+                o.object_type = "String"
+                o.value = [cybox_obj.custom_properties[0].value]
+                return o
     elif isinstance(cybox_obj, Disk):
         o.object_type = "Disk"
         o.name = str(cybox_obj.type)
@@ -418,10 +437,6 @@ def make_crits_object(cybox_obj):
     elif isinstance(cybox_obj, Process):
         o.object_type = "Process"
         o.value = get_object_values(cybox_obj.name)
-        return o
-    elif isinstance(cybox_obj, String):
-        o.object_type = "String"
-        o.value = get_object_values(cybox_obj.value)
         return o
     elif isinstance(cybox_obj, System):
         o.object_type = "System"

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -258,12 +258,11 @@ class STIXParser():
                     for value in obj.value:
                         if value and ind_type:
                             res = handle_indicator_ind(value.strip(),
-                                                    self.source,
-                                                    None,
-                                                    ind_type,
-                                                    analyst,
-                                                    add_domain=True,
-                                                    add_relationship=True)
+                                                       self.source,
+                                                       ind_type,
+                                                       analyst,
+                                                       add_domain=True,
+                                                       add_relationship=True)
                             if res['success']:
                                 self.imported[indicator.id_] = (Indicator._meta['crits_type'],
                                                                 res['object'])
@@ -430,7 +429,6 @@ class STIXParser():
                             if value and ind_type:
                                 res = handle_indicator_ind(value.strip(),
                                                         self.source,
-                                                        None,
                                                         ind_type,
                                                         analyst,
                                                         add_domain=True,

--- a/crits/standards/parsers.py
+++ b/crits/standards/parsers.py
@@ -65,7 +65,10 @@ class STIXParser():
         self.source_instance.method = method
         self.information_source = None
 
-        self.imported = [] # track items that are imported
+        self.event = None # the Event TLO
+        self.event_rels = {} # track relationships to the event
+        self.relationships = [] # track other relationships that need forming
+        self.imported = {} # track items that are imported
         self.failed = [] # track STIX/CybOX items that failed import
         self.saved_artifacts = {}
 
@@ -139,8 +142,15 @@ class STIXParser():
                                 date,
                                 self.source_instance.analyst)
             if res['success']:
-                self.imported.append(('Event',
-                                      res['object']))
+                self.event = res['object']
+                self.imported[self.package.id_] = ('Event', res['object'])
+
+                # Get relationships to the Event
+                if self.package.incidents:
+                    incdnts = self.package.incidents
+                    for rel in getattr(incdnts[0], 'related_indicators', ()):
+                        self.event_rels[rel.item.idref] = (rel.relationship.value,
+                                                           rel.confidence.value.value)
             else:
                 self.failed.append((res['message'],
                                     "STIX Event",
@@ -200,7 +210,8 @@ class STIXParser():
                                             il,
                                             analyst)
                         obj = Actor.objects(id=res['id']).first()
-                        self.imported.append((Actor._meta['crits_type'], obj))
+                        self.imported[threat_actor.id_] = (Actor._meta['crits_type'],
+                                                           obj)
                     else:
                         self.failed.append((res['message'],
                                             type(threat_actor).__name__,
@@ -219,6 +230,23 @@ class STIXParser():
 
         analyst = self.source_instance.analyst
         for indicator in indicators: # for each STIX indicator
+
+            # store relationships
+            for rel in getattr(indicator, 'related_indicators', ()):
+                self.relationships.append((indicator.id_,
+                                           rel.relationship.value,
+                                           rel.item.idref,
+                                           rel.confidence.value.value))
+
+            # handled indicator-wrapped observable
+            if getattr(indicator, 'title', ""):
+                if "Top-Level Object" in indicator.title:
+                    self.parse_observables(indicator.observables)
+                    result = self.imported.pop(indicator.observables[0].id_, None)
+                    if result:
+                        self.imported[indicator.id_] = result
+                    continue
+
             for observable in indicator.observables: # get each observable from indicator (expecting only 1)
                 try: # create CRITs Indicator from observable
                     item = observable.object_.properties
@@ -237,8 +265,8 @@ class STIXParser():
                                                     add_domain=True,
                                                     add_relationship=True)
                             if res['success']:
-                                self.imported.append((Indicator._meta['crits_type'],
-                                                    res['object']))
+                                self.imported[indicator.id_] = (Indicator._meta['crits_type'],
+                                                                res['object'])
                             else:
                                 self.failed.append((res['message'],
                                                     type(item).__name__,
@@ -378,6 +406,12 @@ class STIXParser():
                                             "STIX")
                     # Should check for attachments and add them here.
                     self.parse_res(imp_type, obs, res)
+                    if res.get('status') and item.attachments:
+                        for attach in item.attachments:
+                            rel_id = attach.to_dict()['object_reference']
+                            self.relationships.append((obs.id_,
+                                                       "Contains",
+                                                       rel_id, "High"))
                 else: # try to parse all other possibilities as Indicator
                     imp_type = "Indicator"
                     obj = make_crits_object(item)
@@ -412,8 +446,8 @@ class STIXParser():
         if s is None:
             s = res.get('status', None)
         if s:
-            self.imported.append((imp_type,
-                                    res['object'])) # use class to parse object
+            self.imported[obs.id_] = (imp_type,
+                                      res['object']) # use class to parse object
         else:
             if 'reason' in res:
                 msg = res['reason']
@@ -442,23 +476,42 @@ class STIXParser():
 
     def relate_objects(self):
         """
-        for now we are relating all objects to each other with a common
-        relationship type that is most likely inaccurate. Need to get actual
-        relationship out of the cybox document once we are storing it there.
+        If an Incident was included in the STIX package, its
+        related_indicators attribute is used to relate objects to the event.
+        Any objects without an explicit relationship to the event are
+        related using type "Related_To".
+
+        Objects are related to each other using the relationships listed in
+        their related_indicators attribute.
         """
-        finished_objects = []
-        for obj in self.imported:
-            if not finished_objects: # Prime the list...
-                finished_objects.append(obj[1])
-                continue
+        analyst = self.source_instance.analyst
 
-            for right in finished_objects:
-                obj[1].add_relationship(right,
-                                     rel_type="Related_To",
-                                     analyst=self.source_instance.analyst)
-            finished_objects.append(obj[1])
+        # relate objects to Event
+        if self.event:
+            evt = self.event
+            for id_ in self.imported:
+                if id_ in self.event_rels:
+                    evt.add_relationship(self.imported[id_][1],
+                                         rel_type=self.event_rels[id_][0],
+                                         rel_confidence=self.event_rels[id_][1],
+                                         analyst=analyst)
+                elif self.imported[id_][0] != 'Event':
+                    evt.add_relationship(self.imported[id_][1],
+                                         rel_type='Related_To',
+                                         rel_confidence='Unknown',
+                                         analyst=analyst)
+            evt.save(username=analyst)
 
-        for f in finished_objects:
-            f.save(username=self.source_instance.analyst)
+        # relate objects to each other
+        for rel in self.relationships:
+            if rel[0] in self.imported and rel[2] in self.imported:
+                left = self.imported[rel[0]][1]
+                right = self.imported[rel[2]][1]
+                left.add_relationship(right,
+                                      rel_type=rel[1],
+                                      rel_confidence=rel[3],
+                                      analyst=analyst)
 
-
+        # save objects
+        for id_ in self.imported:
+            self.imported[id_][1].save(username=analyst)

--- a/crits/standards/templates/import_results.html
+++ b/crits/standards/templates/import_results.html
@@ -6,7 +6,7 @@
     <tr>
         <td colspan="2" style="text-align: center"><b>Imported</b></td>
     </tr>
-            {% for item in imported %}
+            {% for key, item in imported.items %}
                 <tr>
                     <td class="key">
                         {{item.0}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ anyjson
 billiard
 biplist
 celery
-cybox==2.1.0.5
+cybox==2.1.0.11
 defusedxml
 django-celery
 django-tastypie==0.11.0
@@ -29,7 +29,7 @@ requests
 setuptools
 simplejson
 six
-stix==1.1.1.0
+stix==1.1.1.5
 ushlex
 wsgiref
 olefile


### PR DESCRIPTION
This PR is an attempt at enabling the sharing of String Indicators and TLO relationships via STIX.

Strings:
- There is no CybOX object type designed for generic strings
- This solution uses the CybOX Custom object
  - Object custom_name = "crits:String"
  - The single custom_property name is "value"
  - This requires an update to cybox-2.1.0.11 and stix-1.1.1.5
  - This is intended to address #442

Relationships:
- In order to describe via STIX the inter-object relationships, all Observables are wrapped within a STIX Indicator (I'm not a huge fan of this Observable wrapping and I expect @mgoffin won't be either, so I'm open to suggestions :smiley:)
  - The STIX Indicator title and description indicate that the Indicator is simply a wrapper
  - The STIX Indicator's related_indicators attribute describes the relationships using references to other STIX Indicators
  - We could only wrap those Observables that actually have relationships, but I thought it might be better to consistently wrap all of them
- Email attachments are automatically included with an Email
  - The Sample is added as its own Indicator-wrapped Observable
  - The Sample is referenced in the "attachments" attribute of the Email
  - The relationship between the Email and the Sample is documented in the related_indicators attribute of their respective Indicator wrapper
  - This attempts to address #437 
- In order to describe via STIX the Event -> Object relationships, an Incident is added to the STIX output. (I'm not a huge fan of this either, so again, I'm open to suggestions)
  - Relationships to Indicators and Indicator-wrapped Observables are listed in the Incident's related_indicators attribute.
  - Any objects for which a relationship to the Event is not defined are assigned a "Related_To" relationship.