### PR TITLE
Bootstrap fixes for OSX

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -67,7 +67,7 @@ then
     echo "Installation for OSX requires Homebrew. Please visit http://brew.sh/."
     exit
   }
-  brew install mongodb ssdeep upx p7zip libyaml pcre libxml2 openssl
+  brew install mongodb ssdeep upx p7zip libmagic libyaml pcre libxml2 openssl
   brew install https://raw.githubusercontent.com/destijl/homebrew-versions/master/swig304.rb
 elif [ "$OS" = 'freebsd' ]
 then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -69,6 +69,10 @@ then
   }
   brew install mongodb ssdeep upx p7zip libmagic libyaml pcre libxml2 openssl
   brew install https://raw.githubusercontent.com/destijl/homebrew-versions/master/swig304.rb
+  command -v pip >/dev/null 2>&1 || {
+    echo "Installation for OSX requires pip. We will try to install pip now."
+    sudo easy_install pip
+  }  
 elif [ "$OS" = 'freebsd' ]
 then
   echo "Installing ports"


### PR DESCRIPTION

...
 from crits.core.mongo_tools import mongo_connector
  File "/Users/adam/Downloads/crits/crits/core/mongo_tools.py", line 8, in <module>
    import magic
  File "/Library/Python/2.7/site-packages/magic.py", line 161, in <module>
    raise ImportError('failed to find libmagic.  Check your installation')