### PR TITLE
Changes actions API key from 'Actor' => 'Actors'

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -643,7 +643,7 @@ class CRITsAPIResource(MongoEngineResource):
             'Common': {
                 'run_service': servh.run_service,
             },
-            'Actor': {
+            'Actors': {
                 'update_actor_tags': ah.update_actor_tags,
                 'attribute_actor_identifier': ah.attribute_actor_identifier,
                 'set_identifier_confidence': ah.set_identifier_confidence,


### PR DESCRIPTION
Fixes a key miss that was happening on PATCH API calls for actors. The key was 'Actor' when it should've been 'Actors'

Relevant discussion: https://github.com/crits/crits/pull/449