### PR TITLE
Bootstrap updates

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -108,7 +108,7 @@ chmod 664 logs/crits.log
 if [ ! -f crits/config/database.py ]; then
   echo "Creating default database configuration file"
   cp crits/config/database_example.py crits/config/database.py
-  SC="$(cat /dev/urandom | tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)' | fold -w 50 | head -n 1)"
+  SC=$(cat /dev/urandom | tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)' | fold -w 50 | head -n 1)
   # This is going to escape the '&' character that is a special character in sed 
   SE=$(echo ${SC} | sed -e 's/&/\\\&/g')
   sed -i -e "s/^\(SECRET_KEY = \).*$/\1\'${SE}\'/1" crits/config/database.py

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -108,7 +108,7 @@ chmod 664 logs/crits.log
 if [ ! -f crits/config/database.py ]; then
   echo "Creating default database configuration file"
   cp crits/config/database_example.py crits/config/database.py
-  SC=$(cat /dev/urandom | tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)' | fold -w 50 | head -n 1)
+  SC=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)' | fold -w 50 | head -n 1)
   # This is going to escape the '&' character that is a special character in sed 
   SE=$(echo ${SC} | sed -e 's/&/\\\&/g')
   sed -i -e "s/^\(SECRET_KEY = \).*$/\1\'${SE}\'/1" crits/config/database.py

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -42,9 +42,9 @@ then
   echo "Installing dependencies with apt-get"
   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
   echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-
+  sudo apt-add-repository universe
   sudo apt-get update
-  sudo apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep unrar upx zip swig libssl-dev
+  sudo apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep unrar-free upx zip swig libssl-dev
   sudo ldconfig
 
 # Redhat: Install as many dependencies as we can using yum.
@@ -108,7 +108,7 @@ chmod 664 logs/crits.log
 if [ ! -f crits/config/database.py ]; then
   echo "Creating default database configuration file"
   cp crits/config/database_example.py crits/config/database.py
-  SC="$(python contrib/gen_secret_key.py)"
+  SC="$(cat /dev/urandom | tr -dc 'abcdefghijklmnopqrstuvwxyz0123456789!@#%^&*(-_=+)' | fold -w 50 | head -n 1)"
   # This is going to escape the '&' character that is a special character in sed 
   SE=$(echo ${SC} | sed -e 's/&/\\\&/g')
   sed -i -e "s/^\(SECRET_KEY = \).*$/\1\'${SE}\'/1" crits/config/database.py
@@ -137,7 +137,7 @@ if [ $? -eq 0 ]
 then
   # Setup the first admin user.
   read -p "Username: " USERNAME
-  read -p  "First name: " FIRSTNAME
+  read -p "First name: " FIRSTNAME
   read -p "Last name: " LASTNAME
   read -p "Email address: " EMAIL
   read -p "Organization name: " ORG


### PR DESCRIPTION
Summary of changes:
- addirng Universe repo for Ubuntu. Without universe repo some of the dependencies are missing on Ubuntu.
- Generate the random key without using the python script. When apt-get would fail, the user would end up with an empty SECRET_KEY, and more failures that are harder to troubleshoot. 
- Change unrar to unrar-free to fix ubuntu-15.04
- remove an extra space

We can now probably retire crits/contrib/gen_secret_key.py