### PR TITLE
Domain TLDs Stale

### DIFF
--- a/crits/domains/handlers.py
+++ b/crits/domains/handlers.py
@@ -43,10 +43,14 @@ def get_valid_root_domain(domain):
     if any(c in black_list for c in domain):
         error = 'Domain cannot contain space or characters %s' % (black_list)
     else:
+        global tld_parser
         root = tld_parser.parse(domain)
         if root == "no_tld_found_error":
-            error = 'No valid TLD found'
-            root = ""
+            tld_parser = etld()
+            root = tld_parser.parse(domain)
+            if root == "no_tld_found_error":
+                error = 'No valid TLD found'
+                root = ""
         else:
             fqdn = domain.lower()
 


### PR DESCRIPTION
Add a workaround to the tld parser. If it can't find a domain then re-query the tld collection to get the most up to date information. Fixes #513.

Keep in mind this would not be a solution in the situation where someone decides to remove TLDs. In that case you'd need to restart the web server.
