### PR TITLE
Fixed unsupported Unicode Campaign names on Dashboards ->Top Campaigns table 

### DIFF
--- a/crits/dashboards/utilities.py
+++ b/crits/dashboards/utilities.py
@@ -59,7 +59,7 @@ def getHREFLink(object, object_type):
         key = "id"
     #adding the last part of the url 
     if key in object:
-        href += str(object[key]) + "/"
+        href += unicode(object[key]) + "/"
     return href
 
 def get_obj_name_from_title(tableTitle):


### PR DESCRIPTION
If campaign name was not in English,
"UnicodeEncodeError as /dashbaords/" is received with exception "'ascii' codec can't encode characters in position ... ".
the problem is in line 62: href += str(object[key]) + "/" 
in non-English name situation line will fail.
