### PR TITLE
Removed a huge memory issue

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -1608,7 +1608,8 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
 
         from crits.objects.handlers import delete_object_file
         for o in self.obj:
-            delete_object_file(o.value)
+            if o.datatype == 'file':
+                delete_object_file(o.value)
         self.obj = []
 
     def delete_all_favorites(self):


### PR DESCRIPTION
Do file checks when objects are of file datatype and
ensure filenames are of md5sum hashes when looking
to delete files.

Found when indicators are deleted it takes time and eats up
a ton of memory.  The big bottleneck was when Objects of the
Indicators were removed it brute forced file look ups
especially when they weren't of enum type 'file'.
mongoengine looked up and cached all files of the TLO's to ensure
there were no other references before deleting the file.

In cases of LARGE databases this took minutes to delete one
indicator and ate up gigs of memory.

https://github.com/crits/crits/issues/530