### PR TITLE
Fix get_dialog with invalid dialog.

### DIFF
--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -185,9 +185,16 @@ def get_dialog(request):
 
     dialog = request.GET.get('dialog', '')
     # Regex in urls.py doesn't seem to be working, should sanity check dialog
-    return render_to_response(dialog + ".html",
-                              {"error" : 'Dialog not found'},
-                              RequestContext(request))
+    try:
+        resp = render_to_response(dialog + ".html",
+                                  {"error" : 'Dialog not found'},
+                                  RequestContext(request))
+    except Exception as e:
+        resp = render_to_response("error.html",
+                                  {"error": "Dialog not found"},
+                                  RequestContext(request))
+    return resp
+
 
 @user_passes_test(user_can_view_data)
 def update_status(request, type_, id_):


### PR DESCRIPTION
Don't throw a 500 if someone asks for an invalid dialog. Instead return
the error page.