### PR TITLE
StringIO to BytesIO changes for portability

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -1,6 +1,6 @@
 import datetime
 import json, yaml
-import StringIO
+import io
 import csv
 
 from bson import json_util, ObjectId
@@ -502,7 +502,7 @@ class CritsDocument(BaseDocument):
 
         if not fields:
             fields = self._data.keys()
-        csv_string = StringIO.StringIO()
+        csv_string = io.BytesIO()
         csv_wr = csv.writer(csv_string)
         if headers:
             csv_wr.writerow([f.encode('utf-8') for f in fields])

--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -589,7 +589,7 @@ def generate_qrcode(data, size):
     """
     Generate a QR Code Image from a string.
 
-    Will attempt to import qrcode (which also requires Pillow) and StringIO. If
+    Will attempt to import qrcode (which also requires Pillow) and io. If
     this fails we will return None.
 
     :param data: data to be converted into a QR Code
@@ -600,10 +600,10 @@ def generate_qrcode(data, size):
     """
 
     try:
-        import qrcode, StringIO
+        import qrcode, io
     except:
         return None
-    a = StringIO.StringIO()
+    a = io.BytesIO()
     qr = qrcode.QRCode()
     qr.add_data(data)
     img = qr.make_image().resize(size)

--- a/crits/core/fields.py
+++ b/crits/core/fields.py
@@ -4,7 +4,7 @@ from dateutil.parser import parse
 from mongoengine import DateTimeField, FileField
 from mongoengine.connection import DEFAULT_CONNECTION_NAME
 from mongoengine.python_support import str_types
-import StringIO
+import io
 
 from django.conf import settings
 if settings.FILE_DB == settings.S3:
@@ -78,7 +78,7 @@ class S3Proxy(object):
 
         try:
             if self.gridout is None:
-                self.gridout = StringIO.StringIO(S3.get_file_s3(self.grid_id, self.collection_name))
+                self.gridout = io.BytesIO(S3.get_file_s3(self.grid_id, self.collection_name))
             return self.gridout
         except:
             return None

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -9,7 +9,7 @@ import json
 import magic
 import re
 import yaml
-import StringIO
+import io
 import sys
 import olefile
 
@@ -1447,7 +1447,7 @@ def parse_ole_file(file):
 
     file.seek(0)
     data = file.read()
-    msg_file = StringIO.StringIO(data)
+    msg_file = io.BytesIO(data)
     ole = olefile.OleFileIO(msg_file)
 
     # Helper function to grab data out of stream objects

--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -4,7 +4,7 @@ import json
 import logging
 import urlparse
 
-from cStringIO import StringIO
+from io import BytesIO
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.urlresolvers import reverse
@@ -364,7 +364,7 @@ def handle_indicator_csv(csv_data, source, method, reference, ctype, username,
         cdata = csv_data.read()
     else:
         cdata = csv_data.encode('ascii')
-    data = csv.DictReader(StringIO(cdata), skipinitialspace=True)
+    data = csv.DictReader(BytesIO(cdata), skipinitialspace=True)
     result = {'success': True}
     result_message = ""
     # Compute permitted values in CSV


### PR DESCRIPTION
I'd like to change the instances of StringIO to BytesIO for more future proof  implementation.