### PR TITLE
Fix a missed relationship conversion

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -990,7 +990,7 @@ def handle_file(filename, data, source, method='Generic', reference='', related_
             if related_obj.id != sample.id: #don't form relationship to itself
                 if not relationship:
                     if related_obj._meta['crits_type'] == 'Email':
-                        relationship = "Contained_Within"
+                        relationship = RelationshipTypes.CONTAINED_WITHIN
                     else:
                         relationship = RelationshipTypes.RELATED_TO
                 sample.add_relationship(related_obj,


### PR DESCRIPTION
"Contained_Within" was missed, this should be the proper fix to get the attachments from emails properly related. There is a PR to fix these things for services https://github.com/crits/crits_services/pull/141
