### PR TITLE
Remove Sector References from prep.py

### DIFF
--- a/crits/core/management/commands/prep.py
+++ b/crits/core/management/commands/prep.py
@@ -7,8 +7,6 @@ from django.core.management.base import BaseCommand
 from crits.config.config import CRITsConfig
 from crits.core.mongo_tools import mongo_update, mongo_remove, mongo_connector
 
-from create_sectors import add_sector_objects
-
 
 
 logger = logging.getLogger(__name__)
@@ -151,10 +149,6 @@ def prep_notifications():
     query = {"type": "notification"}
     mongo_remove(settings.COL_COMMENTS, query)
 
-def prep_sectors():
-
-    add_sector_objects()
-
 def prep_indexes():
     """
     Update indexing.
@@ -176,7 +170,6 @@ def prep_database():
     """
 
     prep_notifications()
-    prep_sectors()
     prep_indexes()
     update_database_version()
     return


### PR DESCRIPTION
Removing obsolete references to sectors in prep.py since this functionality is now in CRITs vocabularies. This was preventing users from running python manage.py upgrade -S [and -D]

Closes #570 