### PR TITLE
Better Parse EML Error Message

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -975,7 +975,9 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
     msg = eml.message_from_string(str(stripped_mail))
 
     if not msg.items():
-        result['reason'] = "No items found."
+        result['reason'] = """Could not parse email. Either not enough
+                           data or the input does not conform to a Internet
+                           Message style headers and header continuation lines"""
         return result
 
     # clean up headers

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -975,9 +975,9 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
     msg = eml.message_from_string(str(stripped_mail))
 
     if not msg.items():
-        result['reason'] = """Could not parse email. Either not enough
-                           data or the input does not conform to a Internet
-                           Message style headers and header continuation lines"""
+        result['reason'] = """Could not parse email. Possibly the input does
+                           not conform to a Internet Message style headers
+                           and header continuation lines..."""
         return result
 
     # clean up headers


### PR DESCRIPTION
When uploading a RAW email, the error message "No items found" is cryptic because normally you would only get that error if the EML is malformed.

Repeatable by giving invalid EML. 

Doesn't work:

```
from:me
to:you
```

Works:

```
from: me
to: you
```