### PR TITLE
Fix XSS in jtable name.

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2024,8 +2024,7 @@ def jtable_ajax_list(col_obj,url,urlfieldparam,request,excludes=[],includes=[],q
                             doc[key] = ",".join(value)
                     else:
                         doc[key] = ""
-                if key != urlfieldparam:
-                    doc[key] = html_escape(doc[key])
+                doc[key] = html_escape(doc[key])
             if col_obj._meta['crits_type'] == "Comment":
                 mapper = {
                     "Actor": 'crits.actors.views.actor_detail',


### PR DESCRIPTION
Best example of this is in bucket lists. Put this as a bucket list on an
item:

/textarea><sCrIpt>alert('xss3')</ScrIPt>

then view the "/bucket/list/" url and you should get an alert.

Fix it by escaping the term.