### PR TITLE
Fix infinite recursion bug in type filter and return a string as documented

### DIFF
--- a/crits/core/templatetags/filters.py
+++ b/crits/core/templatetags/filters.py
@@ -74,8 +74,8 @@ def does_field_have_indicator(field, relationships):
 
     return return_value
 
-@register.filter
-def type(value):
+@register.filter(name="type")
+def typeOf(value):
     """
     Get the type of value.
 
@@ -84,7 +84,7 @@ def type(value):
     :returns: str
     """
 
-    return type(value)
+    return str(type(value))
 
 @register.filter
 def nicify(value):


### PR DESCRIPTION
This fixes the type filter calling itself rather than the built-in type function.
The type is also converted to a string before being returned to match the documented return type.