### PR TITLE
Fix creating initial admin account in bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -167,7 +167,7 @@ then
   read -p "Organization name: " ORG
   
   echo "Adding a default admin account"
-  python manage.py users -a -A -e "$EMAIL" -f "$FIRSTNAME" -l "$LASTNAME" -o "$ORG" -u "$USERNAME"
+  python manage.py users -a -A -s -e "$EMAIL" -f "$FIRSTNAME" -l "$LASTNAME" -o "$ORG" -u "$USERNAME"
   echo "Make note of the above password so you can authenticate!"
   
   # Attempt to start the runserver.


### PR DESCRIPTION
The initial admin account created by the bootstrap script must be set as active for the user to log in.
Otherwise, the user would need to run `python manage.py users -s <username>` before they could log in.