### PR TITLE
Returning the ObjectId was failing in JSON serialize for API submission

### DIFF
--- a/crits/emails/api.py
+++ b/crits/emails/api.py
@@ -130,7 +130,7 @@ class EmailResource(CRITsAPIResource):
         if result.get('reason'):
             content['message'] += result.get('reason')
         if result.get('obj_id'):
-            content['id'] = result.get('obj_id', '')
+            content['id'] = str(result.get('obj_id', ''))
         elif result.get('object'):
             content['id'] = str(result.get('object').id)
         if content.get('id'):


### PR DESCRIPTION
Added a call to str() on the returned objectId to allow success

- Possibly, a more correct fix would be to ensure obj_id is a string when created in handler.py, or to use a mongoEngine that allows an ObjectId to be serialized.