### PR TITLE
Added tickets and bucket_list support for uploaded emails.

### DIFF
--- a/crits/emails/api.py
+++ b/crits/emails/api.py
@@ -70,6 +70,8 @@ class EmailResource(CRITsAPIResource):
         reference = bundle.data.get('reference', None)
         campaign = bundle.data.get('campaign', None)
         confidence = bundle.data.get('confidence', None)
+        bucket_list = bundle.data.get('bucket_list', None)
+        ticket = bundle.data.get('ticket', None)
 
         if method:
             method = " - " + method
@@ -82,7 +84,7 @@ class EmailResource(CRITsAPIResource):
             filedata = file_.read()
             result = handle_eml(filedata, source, reference,
                                 analyst, 'EML Upload' + method, campaign,
-                                confidence)
+                                confidence, bucket_list, ticket)
         if type_ == 'msg':
             raw_email = bundle.data.get('filedata', None)
             password = bundle.data.get('password', None)
@@ -93,7 +95,9 @@ class EmailResource(CRITsAPIResource):
                                 'Outlook MSG Upload' + method,
                                 password,
                                 campaign,
-                                confidence)
+                                confidence,
+                                bucket_list,
+                                ticket)
         if type_ == 'raw':
             raw_email = bundle.data.get('filedata', None)
             result = handle_pasted_eml(raw_email,
@@ -102,7 +106,9 @@ class EmailResource(CRITsAPIResource):
                                        analyst,
                                        'Raw Upload' + method,
                                        campaign,
-                                       confidence)
+                                       confidence,
+                                       bucket_list,
+                                       ticket)
         if type_ == 'yaml':
             yaml_data = bundle.data.get('filedata', None)
             email_id = bundle.data.get('email_id', None)
@@ -115,7 +121,9 @@ class EmailResource(CRITsAPIResource):
                                  email_id,
                                  save_unsupported,
                                  campaign,
-                                 confidence)
+                                 confidence,
+                                 bucket_list,
+                                 ticket)
         if type_ == 'fields':
             fields = bundle.data
             # Strip these so they don't get put in unsupported_attrs.

--- a/crits/emails/api.py
+++ b/crits/emails/api.py
@@ -84,7 +84,7 @@ class EmailResource(CRITsAPIResource):
             filedata = file_.read()
             result = handle_eml(filedata, source, reference,
                                 analyst, 'EML Upload' + method, campaign,
-                                confidence, bucket_list, ticket)
+                                confidence, bucket_list=bucket_list, ticket=ticket)
         if type_ == 'msg':
             raw_email = bundle.data.get('filedata', None)
             password = bundle.data.get('password', None)
@@ -96,8 +96,8 @@ class EmailResource(CRITsAPIResource):
                                 password,
                                 campaign,
                                 confidence,
-                                bucket_list,
-                                ticket)
+                                bucket_list=bucket_list,
+                                ticket=ticket)
         if type_ == 'raw':
             raw_email = bundle.data.get('filedata', None)
             result = handle_pasted_eml(raw_email,
@@ -107,8 +107,8 @@ class EmailResource(CRITsAPIResource):
                                        'Raw Upload' + method,
                                        campaign,
                                        confidence,
-                                       bucket_list,
-                                       ticket)
+                                       bucket_list=bucket_list,
+                                       ticket=ticket)
         if type_ == 'yaml':
             yaml_data = bundle.data.get('filedata', None)
             email_id = bundle.data.get('email_id', None)
@@ -122,8 +122,8 @@ class EmailResource(CRITsAPIResource):
                                  save_unsupported,
                                  campaign,
                                  confidence,
-                                 bucket_list,
-                                 ticket)
+                                 bucket_list=bucket_list,
+                                 ticket=ticket)
         if type_ == 'fields':
             fields = bundle.data
             # Strip these so they don't get put in unsupported_attrs.

--- a/crits/emails/forms.py
+++ b/crits/emails/forms.py
@@ -43,6 +43,8 @@ class EmailOutlookForm(forms.Form):
                                              ("low", "low"),
                                              ("medium", "medium"),
                                              ("high", "high")]
+        add_bucketlist_to_form(self)
+        add_ticket_to_form(self)
 
 class EmailYAMLForm(forms.Form):
     """
@@ -76,6 +78,8 @@ class EmailYAMLForm(forms.Form):
                                              ("low", "low"),
                                              ("medium", "medium"),
                                              ("high", "high")]
+        add_bucketlist_to_form(self)
+        add_ticket_to_form(self)
 
 class EmailEMLForm(forms.Form):
     """
@@ -108,6 +112,8 @@ class EmailEMLForm(forms.Form):
                                              ("low", "low"),
                                              ("medium", "medium"),
                                              ("high", "high")]
+        add_bucketlist_to_form(self)
+        add_ticket_to_form(self)
 
 class EmailRawUploadForm(forms.Form):
     """
@@ -140,6 +146,8 @@ class EmailRawUploadForm(forms.Form):
                                              ("low", "low"),
                                              ("medium", "medium"),
                                              ("high", "high")]
+        add_bucketlist_to_form(self)
+        add_ticket_to_form(self)
 
 class EmailUploadForm(forms.Form):
     """

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -948,7 +948,6 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
             'data': None,
             'attachments': {}
           }
-
     if not sourcename:
         result['reason'] = "Missing source information."
         return result
@@ -1096,7 +1095,7 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
         result['object'].reload()
         run_triage(result['object'], analyst)
     except Exception, e:
-        result['reason'] = "Failed to save email.\n<br /><pre>" + \
+        result['reason'] = "Failed1 to save email.\n<br /><pre>" + \
             str(e) + "</pre>"
         return result
 

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -518,13 +518,11 @@ def handle_email_fields(data, analyst, method):
         pass
 
     new_email = Email()
-    new_email.merge(data)
-
     if bucket_list:
         new_email.add_bucket_list(bucket_list, analyst)
     if ticket:
         new_email.add_ticket(ticket, analyst)
-
+    new_email.merge(data)
     new_email.source = [create_embedded_source(sourcename,
                                                reference=reference,
                                                method=method,
@@ -600,12 +598,10 @@ def handle_json(data, sourcename, reference, analyst, method,
     result['data'] = converted
 
     new_email = dict_to_email(result['data'], save_unsupported=save_unsupported)
-
     if bucket_list:
         new_email.add_bucket_list(bucket_list, analyst)
     if ticket:
         new_email.add_ticket(ticket, analyst)
-
     if campaign:
         if not confidence:
             confidence = "low"
@@ -1113,9 +1109,9 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
                                                     rel_type,
                                                     analyst=analyst,
                                                     get_rels=False)
-        if not ret['success']:
-            result['reason'] = "Failed to create relationship.\n<br /><pre>"
-            + result['message'] + "</pre>"
+            if not ret['success']:
+                result['reason'] = "Failed to create relationship.\n<br /><pre>"
+                + result['message'] + "</pre>"
             return result
 
         # Save the email again since it now has a new relationship.

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -550,7 +550,8 @@ def handle_email_fields(data, analyst, method):
     return result
 
 def handle_json(data, sourcename, reference, analyst, method,
-                save_unsupported=True, campaign=None, confidence=None):
+                save_unsupported=True, campaign=None, confidence=None,
+                bucket_list=None, ticket=None):
     """
     Take email in JSON and convert them into an email object.
 
@@ -570,6 +571,10 @@ def handle_json(data, sourcename, reference, analyst, method,
     :type campaign: str
     :param confidence: Confidence level of the campaign.
     :type confidence: str
+    :param bucket_list: The bucket(s) to assign to this data.
+    :type bucket_list: str
+    :param ticket: The ticket to assign to this data.
+    :type ticket: str
     :returns: dict with keys:
               "status" (boolean),
               "object" The email object if successful,
@@ -595,6 +600,12 @@ def handle_json(data, sourcename, reference, analyst, method,
     result['data'] = converted
 
     new_email = dict_to_email(result['data'], save_unsupported=save_unsupported)
+
+    if bucket_list:
+        new_email.add_bucket_list(bucket_list, analyst)
+    if ticket:
+        new_email.add_ticket(ticket, analyst)
+
     if campaign:
         if not confidence:
             confidence = "low"
@@ -624,7 +635,8 @@ def handle_json(data, sourcename, reference, analyst, method,
 
 # if email_id is provided it is the existing email id to modify.
 def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
-                save_unsupported=True, campaign=None, confidence=None):
+                save_unsupported=True, campaign=None, confidence=None,
+                bucket_list=None, ticket=None):
     """
     Take email in YAML and convert them into an email object.
 
@@ -646,6 +658,10 @@ def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
     :type campaign: str
     :param confidence: Confidence level of the campaign.
     :type confidence: str
+    :param bucket_list: The bucket(s) to assign to this data.
+    :type bucket_list: str
+    :param ticket: The ticket to assign to this data.
+    :type ticket: str
     :returns: dict with keys:
               "status" (boolean),
               "object" The email object if successful,
@@ -671,6 +687,10 @@ def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
     result['data'] = converted
 
     new_email = dict_to_email(result['data'], save_unsupported=save_unsupported)
+    if bucket_list:
+        new_email.add_bucket_list(bucket_list, analyst)
+    if ticket:
+        new_email.add_ticket(ticket, analyst)
     if campaign:
         if not confidence:
             confidence = "low"
@@ -731,7 +751,7 @@ def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
 
 
 def handle_msg(data, sourcename, reference, analyst, method, password='',
-               campaign=None, confidence=None):
+               campaign=None, confidence=None, bucket_list=None, ticket=None):
     """
     Take email in MSG and convert them into an email object.
 
@@ -751,6 +771,10 @@ def handle_msg(data, sourcename, reference, analyst, method, password='',
     :type campaign: str
     :param confidence: Confidence level of the campaign.
     :type confidence: str
+    :param bucket_list: The bucket(s) to assign to this data.
+    :type bucket_list: str
+    :param ticket: The ticket to assign to this data.
+    :type ticket: str
     :returns: dict with keys:
               "status" (boolean),
               "obj_id" The email ObjectId if successful,
@@ -769,8 +793,8 @@ def handle_msg(data, sourcename, reference, analyst, method, password='',
     result['email']['source_reference'] = reference
     result['email']['campaign'] = campaign
     result['email']['campaign_confidence'] = confidence
-    result['email']['bucket_list'] = ""
-    result['email']['ticket'] = ""
+    result['email']['bucket_list'] = bucket_list
+    result['email']['ticket'] = ticket
 
     if result['email'].has_key('date'):
         result['email']['isodate'] = date_parser(result['email']['date'],
@@ -825,7 +849,7 @@ def handle_msg(data, sourcename, reference, analyst, method, password='',
 
 def handle_pasted_eml(data, sourcename, reference, analyst, method,
                       parent_type=None, parent_id=None, campaign=None,
-                      confidence=None):
+                      confidence=None, bucket_list=None, ticket=None):
     """
     Take email in EML and convert them into an email object.
 
@@ -847,6 +871,10 @@ def handle_pasted_eml(data, sourcename, reference, analyst, method,
     :type campaign: str
     :param confidence: Confidence level of the campaign.
     :type confidence: str
+    :param bucket_list: The bucket(s) to assign to this data.
+    :type bucket_list: str
+    :param ticket: The ticket to assign to this data.
+    :type ticket: str
     :returns: dict with keys:
               "status" (boolean),
               "reason" (str),
@@ -878,11 +906,12 @@ def handle_pasted_eml(data, sourcename, reference, analyst, method,
         emldata.append(line)
     emldata = "\n".join(emldata)
     return handle_eml(emldata, sourcename, reference, analyst, method, parent_type,
-                      parent_id, campaign, confidence)
+                      parent_id, campaign, confidence, bucket_list, ticket)
 
 
 def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
-               parent_id=None, campaign=None, confidence=None):
+               parent_id=None, campaign=None, confidence=None, bucket_list=None,
+               ticket=None):
     """
     Take email in EML and convert them into an email object.
 
@@ -904,6 +933,10 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
     :type campaign: str
     :param confidence: Confidence level of the campaign.
     :type confidence: str
+    :param bucket_list: The bucket(s) to assign to this data.
+    :type bucket_list: str
+    :param ticket: The ticket to assign to this data.
+    :type ticket: str
     :returns: dict with keys:
               "status" (boolean),
               "reason" (str),
@@ -1037,6 +1070,10 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
     result['data'] = msg_import
 
     new_email = dict_to_email(result['data'])
+    if bucket_list:
+        new_email.add_bucket_list(bucket_list, analyst)
+    if ticket:
+        new_email.add_ticket(ticket, analyst)
     if campaign:
         if not confidence:
             confidence = "low"
@@ -1101,6 +1138,8 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
                        related_type='Email',
                        campaign=campaign,
                        confidence=confidence,
+                       bucket_list=bucket_list,
+                       ticket=ticket,
                        relationship=RelationshipTypes.CONTAINED_WITHIN) == None:
             result['reason'] = "Failed to save attachment.\n<br /><pre>"
             + md5_ + "</pre>"

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -518,11 +518,11 @@ def handle_email_fields(data, analyst, method):
         pass
 
     new_email = Email()
+    new_email.merge(data)
     if bucket_list:
         new_email.add_bucket_list(bucket_list, analyst)
     if ticket:
         new_email.add_ticket(ticket, analyst)
-    new_email.merge(data)
     new_email.source = [create_embedded_source(sourcename,
                                                reference=reference,
                                                method=method,

--- a/crits/emails/views.py
+++ b/crits/emails/views.py
@@ -255,8 +255,8 @@ def email_yaml_add(request, email_id=None):
                       save_unsupported=yaml_form.cleaned_data['save_unsupported'],
                       campaign=yaml_form.cleaned_data['campaign'],
                       confidence=yaml_form.cleaned_data['campaign_confidence'],
-                      bucket_list=eml_form.cleaned_data['bucket_list'],
-                      ticket=eml_form.cleaned_data['ticket'])
+                      bucket_list=yaml_form.cleaned_data['bucket_list'],
+                      ticket=yaml_form.cleaned_data['ticket'])
     if not obj['status']:
         if request.is_ajax():
             json_reply['message'] = obj['reason']
@@ -429,8 +429,8 @@ def email_outlook_add(request):
     password = outlook_form.cleaned_data['password']
     campaign = outlook_form.cleaned_data['campaign']
     campaign_confidence = outlook_form.cleaned_data['campaign_confidence']
-    bucket_list=eml_form.cleaned_data['bucket_list']
-    ticket=eml_form.cleaned_data['ticket']
+    bucket_list = outlook_form.cleaned_data['bucket_list']
+    ticket = outlook_form.cleaned_data['ticket']
 
     result = handle_msg(request.FILES['msg_file'],
                         source,

--- a/crits/emails/views.py
+++ b/crits/emails/views.py
@@ -254,7 +254,9 @@ def email_yaml_add(request, email_id=None):
                       email_id=email_id,
                       save_unsupported=yaml_form.cleaned_data['save_unsupported'],
                       campaign=yaml_form.cleaned_data['campaign'],
-                      confidence=yaml_form.cleaned_data['campaign_confidence'])
+                      confidence=yaml_form.cleaned_data['campaign_confidence'],
+                      bucket_list=eml_form.cleaned_data['bucket_list'],
+                      ticket=eml_form.cleaned_data['ticket'])
     if not obj['status']:
         if request.is_ajax():
             json_reply['message'] = obj['reason']
@@ -316,7 +318,9 @@ def email_raw_add(request):
                     request.user.username,
                     method,
                     campaign=fields_form.cleaned_data['campaign'],
-                    confidence=fields_form.cleaned_data['campaign_confidence'])
+                    confidence=fields_form.cleaned_data['campaign_confidence'],
+                    bucket_list=eml_form.cleaned_data['bucket_list'],
+                    ticket=eml_form.cleaned_data['ticket'])
     if not obj['status']:
         if request.is_ajax():
             json_reply['message'] = obj['reason']
@@ -374,7 +378,9 @@ def email_eml_add(request):
                      request.user.username,
                      method,
                      campaign=eml_form.cleaned_data['campaign'],
-                     confidence=eml_form.cleaned_data['campaign_confidence'])
+                     confidence=eml_form.cleaned_data['campaign_confidence'],
+                     bucket_list=eml_form.cleaned_data['bucket_list'],
+                     ticket=eml_form.cleaned_data['ticket'])
     if not obj['status']:
         json_reply['message'] = obj['reason']
         return render_to_response('file_upload_response.html',
@@ -423,6 +429,8 @@ def email_outlook_add(request):
     password = outlook_form.cleaned_data['password']
     campaign = outlook_form.cleaned_data['campaign']
     campaign_confidence = outlook_form.cleaned_data['campaign_confidence']
+    bucket_list=eml_form.cleaned_data['bucket_list']
+    ticket=eml_form.cleaned_data['ticket']
 
     result = handle_msg(request.FILES['msg_file'],
                         source,
@@ -431,7 +439,9 @@ def email_outlook_add(request):
                         method,
                         password,
                         campaign,
-                        campaign_confidence)
+                        campaign_confidence,
+                        bucket_list,
+                        ticket)
 
     json_reply['success'] = result['status']
     if not result['status']:

--- a/crits/emails/views.py
+++ b/crits/emails/views.py
@@ -319,8 +319,8 @@ def email_raw_add(request):
                     method,
                     campaign=fields_form.cleaned_data['campaign'],
                     confidence=fields_form.cleaned_data['campaign_confidence'],
-                    bucket_list=eml_form.cleaned_data['bucket_list'],
-                    ticket=eml_form.cleaned_data['ticket'])
+                    bucket_list=fields_form.cleaned_data['bucket_list'],
+                    ticket=fields_form.cleaned_data['ticket'])
     if not obj['status']:
         if request.is_ajax():
             json_reply['message'] = obj['reason']


### PR DESCRIPTION
Previously one just couldn't specify ticket number nor bucket_list for an email being uploaded.

This change includes changes to upload forms, and also for the API uploads.