### PR TITLE
First cut at Service provisioning in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,14 @@ Vagrant.configure(2) do |config|
 
   config.vm.network "forwarded_port", guest: 8080, host: 8080
 
+  # Assumes that, if present, the "crits_services" repository is checked out
+  # beside the "crits" repository.
+  if File.exists?("../crits_services")
+    # We use this destination because it's what the other CRITs documentation
+    # refers to.
+    config.vm.synced_folder "../crits_services", "/data/crits_services"
+  end
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
   end

--- a/crits/services/urls.py
+++ b/crits/services/urls.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 from django.conf import settings
@@ -25,5 +26,11 @@ for service_directory in settings.SERVICE_DIRS:
         for d in os.listdir(service_directory):
             abs_path = os.path.join(service_directory, d, 'urls.py')
             if os.path.isfile(abs_path):
-                urlpatterns += patterns('',
-                    url(r'^%s/' % d, include('%s.urls' % d)))
+                # If a service and its dependencies are not installed 
+                # correctly, skip its URLs
+                try:
+                    importlib.import_module("%s.views")
+                    urlpatterns += patterns('',
+                        url(r'^%s/' % d, include('%s.urls' % d)))
+                except ImportError:
+                    pass

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -2,6 +2,7 @@
 
 import errno
 import glob
+import importlib
 import os
 import sys
 import django
@@ -521,12 +522,25 @@ for service_directory in SERVICE_DIRS:
                 cp_items = os.path.join(abs_path, '%s_cp_items.html' % d)
                 view_items = os.path.join(service_directory, d, 'views.py')
                 if os.path.isfile(nav_items):
-                    SERVICE_NAV_TEMPLATES = SERVICE_NAV_TEMPLATES + ('%s_nav_items.html' % d,)
+                    try:
+                        # Assume that importing the views for a service is
+                        # required to use its navigation items.
+                        importlib.import_module("%s.views")
+                    except ImportError:
+                        pass
+                    else:
+                        SERVICE_NAV_TEMPLATES = SERVICE_NAV_TEMPLATES + ('%s_nav_items.html' % d,)
                 if os.path.isfile(cp_items):
                     SERVICE_CP_TEMPLATES = SERVICE_CP_TEMPLATES + ('%s_cp_items.html' % d,)
                 if os.path.isfile(view_items):
                     if '%s_context' % d in open(view_items).read():
-                        TEMPLATE_CONTEXT_PROCESSORS = TEMPLATE_CONTEXT_PROCESSORS + ('%s.views.%s_context' % (d, d),)
+                        context_module = '%s.views.%s_context' % (d, d)
+                        try:
+                            importlib.import_module(context_module)
+                        except ImportError:
+                            pass
+                        else:
+                            TEMPLATE_CONTEXT_PROCESSORS = TEMPLATE_CONTEXT_PROCESSORS + (context_module,)
                 for tab_temp in glob.glob('%s/*_tab.html' % abs_path):
                     head, tail = os.path.split(tab_temp)
                     ctype = tail.split('_')[-2]

--- a/fabfile.py
+++ b/fabfile.py
@@ -51,3 +51,10 @@ def runserver():
     """Run CRITs using the built-in runserver."""
     with cd(APP_ROOT):
         run("python manage.py runserver 0.0.0.0:8080")
+
+
+@task
+def init_services(service_dirs="/data/crits_services"):
+    """Sets the service_dirs config setting and installs dependencies"""
+    with cd(APP_ROOT):
+        run("python manage.py setconfig service_dirs %s" % service_dirs)

--- a/fabfile.py
+++ b/fabfile.py
@@ -34,6 +34,19 @@ def create_admin_user(username=None, firstname=None, lastname=None,
 
 
 @task
+def dev_setup():
+    """Make some basic changes suitable for development environment"""
+    with cd(APP_ROOT):
+        # These let you set the password to a simpler string
+        run("python manage.py setconfig password_complexity_regex '.*'")
+        run("python manage.py setconfig password_complexity_desc 'Anything'")
+        # These aren't strictly required, but CRITs will complain if you try to
+        # change any other settings, if these aren't defined.
+        run("python manage.py setconfig crits_email 'crits@localhost'")
+        run("python manage.py setconfig instance_url 'http://localhost:8080/'")
+
+
+@task
 def runserver():
     """Run CRITs using the built-in runserver."""
     with cd(APP_ROOT):

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -153,6 +153,8 @@ then
   echo "To get a usable system, you still need to use fabric to:"
   echo "- Create an administrator account"
   echo "    $ fab vagrant create_admin_user"
+  echo "- (Optional) Set some development-specific CRITs config settings"
+  echo "    $ fab vagrant dev_setup"
   echo "- Run the development server"
   echo "    $ fab vagrant runserver"
   exit 0

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -155,6 +155,8 @@ then
   echo "    $ fab vagrant create_admin_user"
   echo "- (Optional) Set some development-specific CRITs config settings"
   echo "    $ fab vagrant dev_setup"
+  echo "- (Optional) Set up services"
+  echo "    $ fab vagrant init_services"
   echo "- Run the development server"
   echo "    $ fab vagrant runserver"
   exit 0


### PR DESCRIPTION
Make it easier to have some services installed by default in a Vagrant-provisioned dev environment. The next step would be to automatically install dependencies for services that need them, so those services work too.

cc @packet-rat
