### PR TITLE
Remove import checks for service templates

### DIFF
--- a/crits/services/urls.py
+++ b/crits/services/urls.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 
 from django.conf import settings
@@ -26,11 +25,5 @@ for service_directory in settings.SERVICE_DIRS:
         for d in os.listdir(service_directory):
             abs_path = os.path.join(service_directory, d, 'urls.py')
             if os.path.isfile(abs_path):
-                # If a service and its dependencies are not installed
-                # correctly, skip its URLs
-                try:
-                    importlib.import_module("%s.views" % d)
-                    urlpatterns += patterns('',
-                        url(r'^%s/' % d, include('%s.urls' % d)))
-                except ImportError:
-                    pass
+                urlpatterns += patterns('',
+                    url(r'^%s/' % d, include('%s.urls' % d)))

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -2,7 +2,6 @@
 
 import errno
 import glob
-import imp
 import os
 import sys
 import django
@@ -522,25 +521,13 @@ for service_directory in SERVICE_DIRS:
                 cp_items = os.path.join(abs_path, '%s_cp_items.html' % d)
                 view_items = os.path.join(service_directory, d, 'views.py')
                 if os.path.isfile(nav_items):
-                    try:
-                        # Assume that importing the views for a service is
-                        # required to use its navigation items.
-                        imp.find_module('%s.views' % d)
-                    except ImportError:
-                        pass
-                    else:
-                        SERVICE_NAV_TEMPLATES = SERVICE_NAV_TEMPLATES + ('%s_nav_items.html' % d,)
+                    SERVICE_NAV_TEMPLATES = SERVICE_NAV_TEMPLATES + ('%s_nav_items.html' % d,)
                 if os.path.isfile(cp_items):
                     SERVICE_CP_TEMPLATES = SERVICE_CP_TEMPLATES + ('%s_cp_items.html' % d,)
                 if os.path.isfile(view_items):
                     if '%s_context' % d in open(view_items).read():
                         context_module = '%s.views.%s_context' % (d, d)
-                        try:
-                            imp.find_module(context_module)
-                        except ImportError:
-                            pass
-                        else:
-                            TEMPLATE_CONTEXT_PROCESSORS = TEMPLATE_CONTEXT_PROCESSORS + (context_module,)
+                        TEMPLATE_CONTEXT_PROCESSORS = TEMPLATE_CONTEXT_PROCESSORS + (context_module,)
                 for tab_temp in glob.glob('%s/*_tab.html' % abs_path):
                     head, tail = os.path.split(tab_temp)
                     ctype = tail.split('_')[-2]

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -157,6 +157,10 @@ server_setup()
       echo "To get a usable system, you still need to use fabric to:"
       echo "- Create an administrator account"
       echo "    $ fab vagrant create_admin_user"
+      echo "- (Optional) Set some development-specific CRITs config settings"
+      echo "    $ fab vagrant dev_setup"
+      echo "- (Optional) Set up services"
+      echo "    $ fab vagrant init_services"
       echo "- Run the development server"
       echo "    $ fab vagrant runserver"
       exit 0


### PR DESCRIPTION
Though not ideal, circular import problems were preventing the templates from ever loading, even if dependencies were installed. IMO, this was worse than the state after this PR, where CRITs will fail to load unless you manually remove services with missing dependencies. 