### PR TITLE
Email Create Indicator Fix Plus Sign (+)

### DIFF
--- a/crits/emails/static/js/emails.js
+++ b/crits/emails/static/js/emails.js
@@ -67,7 +67,8 @@ $(document).ready(function(){
     $(".create-indicator").off().click(function(event) {
         var me = $(this);
         data = {
-            'type': $(this).attr('type'),
+            'type': $(this).attr('data-type'),
+            'field': $(this).attr('data-field'),
         };
 
         // Might be nicer if this was a spinning icon, but working with what we have handy

--- a/crits/emails/templates/email_detail.html
+++ b/crits/emails/templates/email_detail.html
@@ -58,16 +58,16 @@
         </tr>
 
         {% for email_field in email_fields %}
-        <tr data-type='{{ email_field.field_type }}'>
+        <tr>
             <td class='key'>{{ email_field.field_displayed_text}}
                 {% if email_field.is_allow_create_indicator %}
                     {% if email_field|does_field_have_indicator:relationships %}
-                        <span type='{{ email_field.field_name }}' title="Create Indicator: Warning: Indicator might already exist" style="float: right;" class="ui-icon ui-icon-circle-plus create-indicator"></span>
+                        <span data-type='{{ email_field.field_type }}' data-field='{{ email_field.field_name }}' title="Create Indicator: Warning: Indicator might already exist" style="float: right;" class="ui-icon ui-icon-circle-plus create-indicator"></span>
                     {% else %}
                         {% if not email_field.field_value or email_field.field_value.strip == "" %}
-                            <span type='{{ email_field.field_name }}' title="Create Indicator: Warning: A value should be supplied first" style="float: right;" class="ui-icon ui-icon-alert create-indicator"></span> 
+                            <span data-type='{{ email_field.field_type }}' data-field='{{ email_field.field_name }}' title="Create Indicator: Warning: A value should be supplied first" style="float: right;" class="ui-icon ui-icon-alert create-indicator"></span> 
                         {% elif email_field.field_value %}
-                            <span type='{{ email_field.field_name }}' title="Create Indicator" style="float: right;" class="ui-icon ui-icon-plusthick create-indicator">"{{email_field.field_value}}"</span>
+                            <span data-type='{{ email_field.field_type }}' data-field='{{ email_field.field_name }}' title="Create Indicator" style="float: right;" class="ui-icon ui-icon-plusthick create-indicator">"{{email_field.field_value}}"</span>
                         {% endif %}
                     {% endif %}
                 {% endif %}

--- a/crits/emails/views.py
+++ b/crits/emails/views.py
@@ -491,7 +491,8 @@ def indicator_from_header_field(request, email_id):
 
     if request.method == "POST" and request.is_ajax():
         if 'type' in request.POST:
-            header_field = request.POST['type']
+            header_field = request.POST.get('field')
+            header_type = request.POST.get('type')
             analyst = request.user.username
             sources = user_sources(analyst)
             email = Email.objects(id=email_id,
@@ -502,15 +503,9 @@ def indicator_from_header_field(request, email_id):
                     'message':  "Could not find email."
                 }
             else:
-                if header_field in ("from_address, sender, reply_to"):
-                    ind_type = "Address - e-mail"
-                elif header_field in ("originating_ip", "x_originating_ip"):
-                    ind_type = "Address - ipv4-addr"
-                else:
-                    ind_type = "String"
                 result = create_indicator_from_header_field(email,
                                                             header_field,
-                                                            ind_type,
+                                                            header_type,
                                                             analyst,
                                                             request)
         else:

--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -586,13 +586,13 @@ def handle_indicator_insert(ind, source, reference='', analyst='', method='',
 
     if ind['type'] not in IndicatorTypes.values():
         return {'success': False,
-                'message': "Not a valid Indicator Type"}
+                'message': "Not a valid Indicator Type: %s" % ind['type']}
     if ind['threat_type'] not in IndicatorThreatTypes.values():
         return {'success': False,
-                'message': "Not a valid Indicator Threat Type"}
+                'message': "Not a valid Indicator Threat Type: %s" % ind['threat_type']}
     if ind['attack_type'] not in IndicatorAttackTypes.values():
         return {'success': False,
-                'message': "Not a valid Indicator Attack Type"}
+                'message': "Not a valid Indicator Attack Type: " % ind['attack_type']}
 
     (ind['value'], error) = validate_indicator_value(ind['value'], ind['type'])
     if error:

--- a/extras/www/static/js/emails.js
+++ b/extras/www/static/js/emails.js
@@ -67,7 +67,8 @@ $(document).ready(function(){
     $(".create-indicator").off().click(function(event) {
         var me = $(this);
         data = {
-            'type': $(this).attr('type'),
+            'type': $(this).attr('data-type'),
+            'field': $(this).attr('data-field'),
         };
 
         // Might be nicer if this was a spinning icon, but working with what we have handy


### PR DESCRIPTION
When on a email details page, clicking the plus sign (+) normally creates an indicator. This was broken because in emails/views.py the indicator types were being set to the following types which are not in the vocabulary anymore. So when you try to create an indicator it complains that it is not a valid indicator type.

```
               if header_field in ("from_address, sender, reply_to"):
                   ind_type = "Address - e-mail"
               elif header_field in ("originating_ip", "x_originating_ip"):
                   ind_type = "Address - ipv4-addr"
               else:
                   ind_type = "String"
```

I updated the code to use the new vocabulary types by putting the types in the correct locations in the email_details.html template and updating the back end to also grab the new field.

I strongly suggest reviewing the code to make sure nothing is wrong because I haven't done much with the indicator stuff after the removal of STIX/CyBOX.