### PR TITLE
Filter out useless notifications

### DIFF
--- a/crits/core/management/commands/generate_notifications.py
+++ b/crits/core/management/commands/generate_notifications.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
         for user in users:
             # only include notifications where the user is in the users list and
             # it wasn't created by them.
-            includes = [x for x in notifications if user.username in x.users and user.username != x.analyst]
+            includes = [x for x in notifications if user.username in x.users and user.username != x.analyst and x.obj_id != None]
 
             # only send an email if there's something to send
             if len(includes):


### PR DESCRIPTION
Filter out entries containing None obj_type and None obj_id from being added to notifications since useless links are created...

The entries that are filtered out are of the form:
\<someuser\> updated a(n) None you are subscribed to: https://\<crits URL\>/details/None/None