### PR TITLE
Added possibility to add results in batch via the api

### DIFF
--- a/crits/services/api.py
+++ b/crits/services/api.py
@@ -1,3 +1,4 @@
+import json
 from django.core.urlresolvers import reverse
 from tastypie import authorization
 from tastypie.authentication import MultiAuthentication

--- a/crits/services/api.py
+++ b/crits/services/api.py
@@ -87,8 +87,7 @@ class ServiceResource(CRITsAPIResource):
                 j_result_subtype = json.loads(result_subtype)
 
                 if not (len(j_result) == len(j_result_type) == len(j_result_subtype)):
-                    content['message'] = 'When adding results in batch result, result_type, ' +
-                                         'and result_subtype must have the same length!'
+                    content['message'] = 'When adding results in batch result, result_type, and result_subtype must have the same length!'
                     self.crits_response(content)
                 for key, r in enumerate(j_result):
                     result = add_result(object_type, object_id, analysis_id,

--- a/documentation/help_main.html
+++ b/documentation/help_main.html
@@ -2685,6 +2685,9 @@ only &quot;date&quot; is required:</p>
 </tr>
 <tr class="field"><th class="field-name">result_subtype:</th><td class="field-body">The 'subtype' of your result.</td>
 </tr>
+<tr class="field"><th class="field-name" colspan="2">result_is_batch:</th></tr>
+<tr class="field"><td>&nbsp;</td><td class="field-body">Set to &quot;1&quot; if you are pushing multiple results.</td>
+</tr>
 <tr class="field"><th class="field-name">log_message:</th><td class="field-body">The contents of the log message.</td>
 </tr>
 <tr class="field"><th class="field-name">log_level:</th><td class="field-body">The level of the log (defaults to 'info').</td>
@@ -2707,6 +2710,10 @@ only &quot;date&quot; is required:</p>
 <p>If you include the &quot;result&quot; field, you will be required to also provide the
 &quot;result_type&quot; and &quot;result_subtype&quot;. Also, if you include the &quot;log_message&quot;
 field, &quot;log_level&quot; will be set to &quot;info&quot; if it is not provided.</p>
+<p>If you want to submit multiple results at once you have to set &quot;result_is_batch&quot;
+to &quot;1&quot; and supply result, result_type, and result_subtype as JSON list. Make sure
+that all three lists have the same length so there is a type and subtype for each
+result.</p>
 </div>
 <div class="section" id="target-api">
 <h2><a class="toc-backref" href="#id99">17.25&nbsp;&nbsp;&nbsp;Target API</a></h2>

--- a/documentation/help_main.txt
+++ b/documentation/help_main.txt
@@ -1846,6 +1846,7 @@ Unique POST Parameters:
 :result: The 'result' contents of your analysis result.
 :result_type: The 'Type' of your result.
 :result_subtype: The 'subtype' of your result.
+:result_is_batch: Set to "1" if you are pushing multiple results.
 :log_message: The contents of the log message.
 :log_level: The level of the log (defaults to 'info').
 :status: The status to set the task to when it is finished.
@@ -1857,6 +1858,11 @@ Unique POST Parameters:
 If you include the "result" field, you will be required to also provide the
 "result_type" and "result_subtype". Also, if you include the "log_message"
 field, "log_level" will be set to "info" if it is not provided.
+
+If you want to submit multiple results at once you have to set "result_is_batch"
+to "1" and supply result, result_type, and result_subtype as JSON list. Make sure
+that all three lists have the same length so there is a type and subtype for each
+result.
 
 Target API
 -------------------------------------------


### PR DESCRIPTION
**Issue**
The service api already exposes the possibility to add results to a TLO which is very important for distributed services. However, a distinct HTTP request is necessary for each result set which puts a lot of unnecessary extra strain on both CRITs and the distributed service.

**Proposal**
By adding the option to send result sets in batch as JSON lists it would be possible to handle many result sets on both sides with a single HTTP request, eliminating a lot of overhead.

**Improvements**
During our internal testing we pushed 5000 result sets to 100 TLOs each on a CRITs machine on the same network. Depending on the size of the result sets we have seen a 20% to 50% speed improvement. We assume the improvement would be even greater for machines not on the same network.

**Known Issues**
None so far, our update doesn't break backwards compatibility and doesn't add any extra strain to non-batch requests.