### PR TITLE
[WIP] Detect malformed date fields when creating a new email TLO.

### DIFF
--- a/crits/emails/email.py
+++ b/crits/emails/email.py
@@ -138,7 +138,11 @@ class Email(CritsBaseAttributes, CritsSourceDocument, Document):
                     self.isodate = self.date
                     self.date = convert_datetimes_to_string(self.date)
                 else:
-                    self.isodate = date_parser(self.date, fuzzy=True)
+                    try:
+                        self.isodate = date_parser(self.date, fuzzy=True)
+                    except:
+                        raise ValueError("Could not parse date, is it malformed?")
+
             else:
                 if self.isodate:
                     if isinstance(self.isodate, datetime.datetime):


### PR DESCRIPTION
When trying to create a new Email TLO using the forms, if you put in a syntactically incorrect date then for the user nothing appears to happen. For example, create a new (Raw) email with the following data:

Date: Tue, 20 Oct 2015 12: 35: 00 +0200

The above has a space between the colon and minute+seconds.

This fix detects an error with the date and returns an error to the user.