### PR TITLE
libjpeg-dev and python-m2crypto are required on Ubuntu

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -248,7 +248,7 @@ ubuntu_install()
     echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
     sudo add-apt-repository universe
     sudo apt-get update
-    sudo apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep upx zip swig libssl-dev
+    sudo apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep upx zip swig libssl-dev libjpeg-dev python-m2crypto
     sudo ldconfig
 }
 


### PR DESCRIPTION
The former is required for PIL.

The later is required because it doesn't compile out of the box on Ubuntu.

These additions make the Vagrant image actually work.