### PR TITLE
Identify the newest available template for each service on get_sample_details

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -169,6 +169,18 @@ def get_sample_details(sample_md5, analyst, format_=None):
 
         # analysis results
         service_results = sample.get_analysis_results()
+        
+        # template
+        from crits.services.core import ServiceManager
+        service_manager     = ServiceManager()
+        tmp_service_results = []
+        
+        for result in service_results:
+            result.template = service_manager.get_service_class(result.service_name).template
+            tmp_service_results.append(result)
+        
+        service_results = tmp_service_results
+        
 
         args = {'objects': objects,
                 'relationships': relationships,


### PR DESCRIPTION
Solution: This pull request will identify the newest available template for a service.

Issue: CRITs queries the analytic_results database to identify the a template path of a service. This in theory could allow CRITs to use a template that is unique for that version of the service. However, the way CRITs is used does not allow this to occur. This is because the services overwrite their core code on every new version. Additionally, the previous method would make it cumbersome to add or change custom templates. 