### PR TITLE
Update Signature TLO Details Page to Not Record Updates During Onload

### DIFF
--- a/crits/signatures/static/js/signatures.js
+++ b/crits/signatures/static/js/signatures.js
@@ -127,7 +127,7 @@ function upload_new_signature_version_dialog_submit(e) {
 }
 
 $(document).ready(function() {
-
+    var loading = true;
     $('#signature_type').editable(function(value, settings) {
         revert = this.revert;
         var her = $(this).closest('tr').find('.object_status_response');
@@ -402,26 +402,26 @@ $(document).ready(function() {
       });
 
 
-      function update_deps(my_tags) {
-        var oid = subscription_id;
-        var itype = subscription_type;
-        var data = {
-           'id': oid,
-           'data_type_dependency': my_tags.toString(),
-           'type': itype
-        };
+     function update_deps(my_tags) {
+        if (!loading) {
+		var oid = subscription_id;
+        	var itype = subscription_type;
+        	var data = {
+           		'id': oid,
+           		'data_type_dependency': my_tags.toString(),
+           		'type': itype
+        	};
 
-
-        $.ajax({
-            type: "POST",
-               url: update_dependency,
-                data: data,
-                 datatype: 'json',
-                 success: function(data) {
-                    // console.log(my_tags);
-                 }
-          });
-
-        }
-
+        	$.ajax({
+            		type: "POST",
+               		url: update_dependency,
+                	data: data,
+                 	datatype: 'json',
+                 	success: function(data) {
+                    		// console.log(my_tags);
+                 	}
+          	});
+	}
+     }
+     loading = false;
 });

--- a/extras/www/static/js/signatures.js
+++ b/extras/www/static/js/signatures.js
@@ -127,7 +127,7 @@ function upload_new_signature_version_dialog_submit(e) {
 }
 
 $(document).ready(function() {
-
+    var loading = true;
     $('#signature_type').editable(function(value, settings) {
         revert = this.revert;
         var her = $(this).closest('tr').find('.object_status_response');
@@ -402,26 +402,26 @@ $(document).ready(function() {
       });
 
 
-      function update_deps(my_tags) {
-        var oid = subscription_id;
-        var itype = subscription_type;
-        var data = {
-           'id': oid,
-           'data_type_dependency': my_tags.toString(),
-           'type': itype
-        };
+     function update_deps(my_tags) {
+        if (!loading) {
+		var oid = subscription_id;
+        	var itype = subscription_type;
+        	var data = {
+           		'id': oid,
+           		'data_type_dependency': my_tags.toString(),
+           		'type': itype
+        	};
 
-
-        $.ajax({
-            type: "POST",
-               url: update_dependency,
-                data: data,
-                 datatype: 'json',
-                 success: function(data) {
-                    // console.log(my_tags);
-                 }
-          });
-
-        }
-
+        	$.ajax({
+            		type: "POST",
+               		url: update_dependency,
+                	data: data,
+                 	datatype: 'json',
+                 	success: function(data) {
+                    		// console.log(my_tags);
+                 	}
+          	});
+	}
+     }
+     loading = false;
 });


### PR DESCRIPTION
The Signature TLO details page was posting/recording updates
to the data type dependency list during page load. This was due to
the location of the update code when performing TagIt activities.

After reviewing the methodology for how Buckets handled this, a
similar update was made to the Signature TLO. Now, the add, update, and
delete calls are only performed after the page has been loaded.

This issue being corrected didn't seem to result in any bad TLO data, just
unnecessary additional calls to the server and an incorrect auditlog entry
added during normal signature details page access.