### PR TITLE
Resolved issues with Indicator POST and RawData PATCH requests.

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -632,7 +632,7 @@ class CRITsAPIResource(MongoEngineResource):
         view, args, kwargs = resolve(uri)
 
         type_ = kwargs['resource_name'].title()
-        if type_ == "Raw_data":
+        if type_ == "Raw_Data":
             type_ = "RawData"
         if type_[-1] == 's':
             type_ = type_[:-1]

--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -544,7 +544,7 @@ def handle_indicator_ind(value, source, ctype, threat_type, attack_type,
         ind['attack_type'] = attack_type.strip()
         ind['value'] = value.strip()
         ind['lower'] = value.lower().strip()
-	ind['description'] = description.strip()
+        ind['description'] = description
 
         if campaign:
             ind['campaign'] = campaign


### PR DESCRIPTION
A typo in core/api was preventing RawData PATCH API requests from completing.  

Attempting to create an Indicator object using a POST API request also fails unless a description is provided.  This is due to an attempt to strip a NoneType object, which is the default value for the "description" argument (description = None).