### PR TITLE
Remove chmod from bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -86,7 +86,6 @@ create_files()
     # The original script had root remain the owner of these files but
     # that ended up causing some difficulties
     sudo chown -R $USER:$GROUP /data
-    chmod -R -v 0755 /data
 }
 
 


### PR DESCRIPTION
Chmod in this case is not desired, since it modifies permissions on the files after bootstrap is run, which impacts the git repo. E.g. git diff shows lots of permission changes.