### PR TITLE
Quick fix for Django 1.9

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2159,7 +2159,7 @@ def get_query(col_obj,request):
             return response
         query.update(qdict)
         term = request.GET['q']
-    qparams = request.REQUEST.copy()
+    qparams = request.GET.copy()
     qparams = check_query(qparams,request.user.username,col_obj)
     for key,value in qparams.items():
         if key in keymaps:


### PR DESCRIPTION
I'm not sure if we use POST anywhere, but definitely most things work with GET.  Django 1.9 deprecates request.REQUEST.