### PR TITLE
Modified add_object handler to prevent conflict with PATCH API requests.

### DIFF
--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -169,7 +169,7 @@ def add_new_handler_object(data, rowData, request, is_validate_only=False,
     object_result = add_object(
         otype, oid, object_type, source, method, reference, analyst,
         value=value, file_=None, add_indicator=add_indicator, get_objects=False,
-        obj=obj, is_validate_only=is_validate_only,
+        tlo=obj, is_validate_only=is_validate_only,
         is_sort_relationships=is_sort_relationships,
         is_validate_locally=is_validate_locally, cache=cache
     )
@@ -193,7 +193,7 @@ def add_new_handler_object(data, rowData, request, is_validate_only=False,
 def add_object(type_, id_, object_type, source, method,
                reference, user, value=None, file_=None,
                add_indicator=False, get_objects=True,
-               obj=None, is_sort_relationships=False,
+               tlo=None, is_sort_relationships=False,
                is_validate_only=False, is_validate_locally=False, cache={},
                **kwargs):
     """
@@ -221,11 +221,11 @@ def add_object(type_, id_, object_type, source, method,
     :type add_indicator: bool
     :param get_objects: Return the formatted list of objects when completed.
     :type get_object: bool
-    :param obj: The CRITs top-level object we are adding objects to.
+    :param tlo: The CRITs top-level object we are adding objects to.
                 This is an optional parameter used mainly for performance
                 reasons (by not querying mongo if we already have the
                 top level-object).
-    :type obj: :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
+    :type tlo: :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
     :param is_validate_only: Validate, but do not add to TLO.
     :type is_validate_only: bool
     :param is_validate_locally: Validate, but do not add b/c there is no TLO.
@@ -241,7 +241,7 @@ def add_object(type_, id_, object_type, source, method,
     """
 
     results = {}
-
+    obj = tlo
     if id_ == None:
         id_ = ""
 


### PR DESCRIPTION
In reference to #701 
When using the PATCH API, the 'obj' argument is passed to all handler functions. The add_object function has a parameter 'obj'. The add_object parameter needs to be renamed to prevent any conflict.