### PR TITLE
Sort services case insensitively, sort users by login date by default.

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2747,7 +2747,7 @@ def generate_users_jtable(request, option):
                             content_type="application/json")
     jtopts = {
         'title': "Users",
-        'default_sort': 'username ASC',
+        'default_sort': 'last_login DESC',
         'listurl': reverse('crits.core.views.users_listing', args=('jtlist',)),
         'deleteurl': None,
         'searchurl': None,

--- a/crits/services/views.py
+++ b/crits/services/views.py
@@ -45,7 +45,11 @@ def list(request):
     List all services.
     """
 
-    all_services = CRITsService.objects().order_by('+name')
+    all_services = CRITsService.objects()
+
+    if all_services:
+        all_services = sorted(all_services, key=lambda item: item.name.lower())
+
     return render_to_response('services_list.html', {'services': all_services},
                               RequestContext(request))
 


### PR DESCRIPTION
This has been annoying me for the LONGEST time. These are control panel changes.

Changed users page to sort by last login date by default.

Changed services page to sort by name, case insensitively.
