### PR TITLE
Fix tests

### DIFF
--- a/crits/dashboards/handlers.py
+++ b/crits/dashboards/handlers.py
@@ -44,9 +44,13 @@ def get_dashboard(user,dashId=None):
             user.save()
     if not dashboard:
         dashboard = Dashboard.objects(name="Default", analystId__not__exists=1, isPublic=True).first()
-        cloneOfDefault = Dashboard.objects(parent=dashboard.id, analystId=user.id).first()
-        if cloneOfDefault:
-            dashboard = cloneOfDefault
+        if dashboard:
+            cloneOfDefault = Dashboard.objects(parent=dashboard.id, analystId=user.id).first()
+            if cloneOfDefault:
+                dashboard = cloneOfDefault
+        else:
+            return {'success': False,
+                'message': "No Default Dashboard. Run 'manage.py create_default_dashboard' to create."}
     dashId = dashboard.id
     tables = []
     savedTables = SavedSearch.objects(dashboard=dashId, isPinned=True)

--- a/crits/relationships/tests.py
+++ b/crits/relationships/tests.py
@@ -3,6 +3,7 @@ from django.test import SimpleTestCase
 from crits.relationships.handlers import forge_relationship, update_relationship_reasons, update_relationship_confidences
 from crits.core.user import CRITsUser
 from crits.campaigns.campaign import Campaign
+from crits.vocabulary.relationships import RelationshipTypes
 
 TUSER_NAME = "test_user"
 TUSER_PASS = "!@#j54kfeimn?>S<D"
@@ -12,7 +13,7 @@ TUSER2_PASS = "!@#saasdfasfwefwe?>S<Dd"
 TUSER2_EMAIL = "asdfsaser@example.com"
 TCAMPAIGN1 = "Test_Campain1"
 TCAMPAIGN2 = "Test_Campain2"
-TRELATIONSHIP_TYPE = "Allocated"
+TRELATIONSHIP_TYPE = RelationshipTypes.RELATED_TO
 TRELATIONSHIP_CONFIDENCE = 'high'
 TRELATIONSHIP_NEW_CONFIDENCE = 'medium'
 TRELATIONSHIP_NEW_REASON = "Because I Said So"


### PR DESCRIPTION
These changes fix two issues that were causing manage.py test to error out:
The issues were:
1. Wrong relationship type was used to create relationship in relationship tests
2. Dashboard handler code was trying to use dashboard.id even when it couldn't find a default dashboard.