### PR TITLE
Moved the datetime variable to prevent actions with duplicate dates.

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1463,12 +1463,12 @@ def do_add_preferred_actions(obj_type, obj_id, username):
         return {'success': False, 'message': 'Could not find object'}
 
     actions = []
-    now = datetime.datetime.now()
     # Get preferred actions and add them.
     for a in preferred_actions:
         for p in a.preferred:
             if (p.object_type == obj_type and
                 obj.__getattribute__(p.object_field) == p.object_value):
+                now = datetime.datetime.now()
                 action = {'action_type': a.name,
                         'active': 'on',
                         'analyst': username,


### PR DESCRIPTION
When attempting to add preferred actions when multiple preferred actions exist, the same "date" value, which serves as a key, was being added to all actions.  This prevented the user from removing and/or modifying the actions.