### PR TITLE
Return Email field value as empty string when not in DB

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -69,7 +69,7 @@ def create_email_field_dict(field_name,
 
     return {"field_name": field_name,
             "field_type": field_type,
-            "field_value": field_value,
+            "field_value": field_value or "",
             "field_displayed_text": field_displayed_text,
             "is_allow_create_indicator": is_allow_create_indicator,
             "is_href": is_href,


### PR DESCRIPTION
If an Email field does not exist in the DB, then its value is returned to the template as None. The template then displays the value as text "None" which may be misleading as it cannot be differentiated from an actual value of string "None". This also leads to an error when an indicator type/value pair is attempted to be generated from the email field as None suggests the desired field doesn't exist. To make matters worse, if a user clicks to edit one of these Email fields, but doesn't actually change it, the field value will be saved as string "None" in the DB.