### PR TITLE
Improve Performance of Object & Relationship Creation

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -1686,7 +1686,7 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
 
     def add_relationship(self, rel_item, rel_type, rel_date=None,
                          analyst=None, rel_confidence='unknown',
-                         rel_reason='N/A', get_rels=False):
+                         rel_reason='', get_rels=False):
         """
         Add a relationship to this top-level object. The rel_item will be
         saved. It is up to the caller to save "self".
@@ -1704,17 +1704,25 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
         :type rel_confidence: str
         :param rel_reason: The reason for the relationship.
         :type rel_reason: str
-        :param get_rels: Return the relationships after forging.
+        :param get_rels: If True, return all relationships after forging.
+                         If False, return the new EmbeddedRelationship object
         :type get_rels: boolean
-        :returns: dict with keys "success" (boolean) and "message" (str if
-                  failed, dict if successful)
+        :returns: dict with keys:
+                  "success" (boolean)
+                  "message" (str if failed, else dict or EmbeddedRelationship)
         """
+
+        # Prevent class from having a relationship to itself
+        if self == rel_item:
+            return {'success': False,
+                    'message': 'Cannot forge relationship to oneself'}
 
         # get reverse relationship
         rev_type = RelationshipTypes.inverse(rel_type)
         if rev_type is None:
             return {'success': False,
                     'message': 'Could not find relationship type'}
+
         date = datetime.datetime.now()
 
         # setup the relationship for me
@@ -1740,93 +1748,54 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
         their_rel.rel_reason = rel_reason
 
         # variables for detecting if an existing relationship exists
-        is_left_rel_exist = False
-        is_right_rel_exist = False
-        left_found_rel = None
-        right_found_rel = None
+        my_existing_rel = None
+        their_existing_rel = None
 
-        # check for existing relationship before
-        # blindly adding them
+        # check for existing relationship before blindly adding
         for r in self.relationships:
-            if rel_date:
-                if (r.object_id == my_rel.object_id
-                    and r.relationship == my_rel.relationship
-                    and r.relationship_date == my_rel.relationship_date
-                    and r.rel_type == my_rel.rel_type):
-                    is_left_rel_exist = True
-                    left_found_rel = r
-            else:
-                if (r.object_id == my_rel.object_id
-                    and r.relationship == my_rel.relationship
-                    and r.rel_type == my_rel.rel_type):
-                    is_left_rel_exist = True
-                    left_found_rel = r
-
-            # If the relationship already exists then we we're done looping
-            if is_left_rel_exist:
-                break
-
+            if (r.object_id == my_rel.object_id
+                and r.relationship == my_rel.relationship
+                and (not rel_date or r.relationship_date == rel_date)
+                and r.rel_type == my_rel.rel_type):
+                my_existing_rel = r
+                break # If relationship already exists then exit loop
         for r in rel_item.relationships:
-            if rel_date:
-                if (r.object_id == their_rel.object_id
-                    and r.relationship == their_rel.relationship
-                    and r.relationship_date == their_rel.relationship_date
-                    and r.rel_type == their_rel.rel_type):
-                    is_right_rel_exist = True
-                    right_found_rel = r
-            else:
-                if (r.object_id == their_rel.object_id
-                    and r.relationship == their_rel.relationship
-                    and r.rel_type == their_rel.rel_type):
-                    is_right_rel_exist = True
-                    right_found_rel = r
-
-            # If the relationship already exists then we we're done looping
-            if is_right_rel_exist:
-                break
+            if (r.object_id == their_rel.object_id
+                and r.relationship == their_rel.relationship
+                and (not rel_date or r.relationship_date == rel_date)
+                and r.rel_type == their_rel.rel_type):
+                their_existing_rel = r
+                break # If relationship already exists then exit loop
 
         # If the relationship already exists on both sides then do nothing
-        if is_left_rel_exist and is_right_rel_exist:
+        if my_existing_rel and their_existing_rel:
             return {'success': False,
                     'message': 'Relationship already exists'}
 
-        # If the relationship does not exist on the left side then add it.
-        if is_left_rel_exist is False:
-            # If the right relationship exists then use the right relationship's data
-            if is_right_rel_exist:
-                my_rel.relationship = right_found_rel.relationship
-                my_rel.analyst = right_found_rel.analyst
-                my_rel.date = right_found_rel.date
-                my_rel.relationship_date = right_found_rel.relationship_date
-                my_rel.rel_confidence = right_found_rel.rel_confidence
-                my_rel.rel_reason = right_found_rel.rel_reason
-                self.relationships.append(my_rel)
-            # otherwise just normally add the new relationship
-            else:
-                self.relationships.append(my_rel)
-
-        # If the relationship does not exist on the right side then add it.
-        if is_right_rel_exist is False:
-            # If the left relationship exists then use the left relationship's data
-            if is_left_rel_exist:
-                their_rel.relationship = left_found_rel.relationship
-                their_rel.analyst = left_found_rel.analyst
-                their_rel.date = left_found_rel.date
-                their_rel.relationship_date = left_found_rel.relationship_date
-                their_rel.rel_confidence = left_found_rel.rel_confidence
-                their_rel.rel_reason = left_found_rel.rel_reason
-                rel_item.relationships.append(their_rel)
-            else:
-                rel_item.relationships.append(their_rel)
-
-            rel_item.save(username=analyst)
+        # Repair unreciprocated relationships
+        if not my_existing_rel: # If my rel does not exist then add it
+            if their_existing_rel: # If their rel exists then use its data
+                my_rel.analyst = their_existing_rel.analyst
+                my_rel.date = their_existing_rel.date
+                my_rel.relationship_date = their_existing_rel.relationship_date
+                my_rel.rel_confidence = their_existing_rel.rel_confidence
+                my_rel.rel_reason = their_existing_rel.rel_reason
+            self.relationships.append(my_rel) # add my new relationship
+        if not their_existing_rel: # If their rel does not exist then add it
+            if my_existing_rel: # If my rel exists then use its data
+                their_rel.analyst = my_existing_rel.analyst
+                their_rel.date = my_existing_rel.date
+                their_rel.relationship_date = my_existing_rel.relationship_date
+                their_rel.rel_confidence = my_existing_rel.rel_confidence
+                their_rel.rel_reason = my_existing_rel.rel_reason
+            rel_item.update(add_to_set__relationships=their_rel) # add new rel
 
         if get_rels:
             results = {'success': True,
                        'message': self.sort_relationships(analyst, meta=True)}
         else:
             results = {'success': True,
-                       'message': 'Relationship forged'}
+                       'message': my_rel}
 
         # In case of relating to a versioned backdoor we also want to relate to
         # the family backdoor.

--- a/crits/core/static/js/bulk_add_default.js
+++ b/crits/core/static/js/bulk_add_default.js
@@ -784,7 +784,7 @@ function parseFailedResults(result, table, errors, isShowIcons)
     }
 }
 
-function parseSuccessfulResults(result, table, progress, isShowIcons, linkData) {
+function parseSuccessfulResults(result, table, progress, isShowIcons, linkData, messages) {
 
     var linkColumnIndex = getColumnIndexFromName(table, LINK_COLUMN_NAME);
 
@@ -798,6 +798,7 @@ function parseSuccessfulResults(result, table, progress, isShowIcons, linkData) 
                 createLiStatusElement(progress.find('#duplicates'), result.successfulRows[thisRow].message, offsetRow, -1, isShowIcons);
             } else {
                 createLiStatusElement(progress.find('#messages'), result.successfulRows[thisRow].message, offsetRow, -1, false);
+                messages.append(result.successfulRows[thisRow].message + '<br>');
             }
         }
 
@@ -843,7 +844,7 @@ function parseResults(result, table, progress, errors, isValidateOnly, offset, i
 
     appendSummary(result, isValidateOnly, progress.find('#messages'), errors, progress);
     parseFailedResults(result, table, errors, isShowIcons);
-    parseSuccessfulResults(result, table, progress, isShowIcons, linkData);
+    parseSuccessfulResults(result, table, progress, isShowIcons, linkData, errors);
 
     updateResultsCounts(progress);
 

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -176,6 +176,8 @@ def add_new_handler_object(data, rowData, request, is_validate_only=False,
 
     if object_result['success']:
         result = True
+        if 'message' in object_result:
+            retVal['message'] = object_result['message']
         if is_validate_only == False:
             if obj == None:
                 obj = class_from_id(otype, oid)

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -192,12 +192,10 @@ def add_new_handler_object(data, rowData, request, is_validate_only=False,
 
     return result, retVal
 
-def add_object(type_, id_, object_type, source, method,
-               reference, user, value=None, file_=None,
-               add_indicator=False, get_objects=True,
-               tlo=None, is_sort_relationships=False,
-               is_validate_only=False, is_validate_locally=False, cache={},
-               **kwargs):
+def add_object(type_, id_, object_type, source, method, reference, user,
+               value=None, file_=None, add_indicator=False, get_objects=True,
+               tlo=None, is_sort_relationships=False, is_validate_only=False,
+               is_validate_locally=False, cache={}, **kwargs):
     """
     Add an object to the database.
 
@@ -222,12 +220,14 @@ def add_object(type_, id_, object_type, source, method,
     :param add_indicator: Also add an indicator for this object.
     :type add_indicator: bool
     :param get_objects: Return the formatted list of objects when completed.
-    :type get_object: bool
+    :type get_objects: bool
     :param tlo: The CRITs top-level object we are adding objects to.
                 This is an optional parameter used mainly for performance
                 reasons (by not querying mongo if we already have the
                 top level-object).
     :type tlo: :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
+    :param is_sort_relationships: Return all relationships and meta, sorted
+    :type is_sort_relationships: bool
     :param is_validate_only: Validate, but do not add to TLO.
     :type is_validate_only: bool
     :param is_validate_locally: Validate, but do not add b/c there is no TLO.
@@ -242,116 +242,96 @@ def add_object(type_, id_, object_type, source, method,
               "relationships" (list)
     """
 
-    results = {}
-    obj = tlo
-    if id_ == None:
-        id_ = ""
-
-    if obj == None:
-        obj = class_from_id(type_, id_)
-
-    from crits.indicators.handlers import validate_indicator_value
-    if value is not None:
+    # if object_type is a validated indicator type, then validate value
+    if value:
+        from crits.indicators.handlers import validate_indicator_value
         (value, error) = validate_indicator_value(value, object_type)
         if error:
             return {"success": False, "message": error}
 
-    if is_validate_locally: # no obj provided
-        results['success'] = True
-        return results
+    if is_validate_locally: # no TLO provided
+        return {"success": True}
 
-    if not obj:
-        results['message'] = "TLO could not be found"
-        results['success'] = False
-        return results
+    if not tlo:
+        if type_ and id_:
+            tlo = class_from_id(type_, id_)
+        if not tlo:
+            return {'success': False, 'message': "Failed to find TLO"}
 
     try:
-        cur_len = len(obj.obj)
         if file_:
             data = file_.read()
             filename = file_.name
             md5sum = md5(data).hexdigest()
             value = md5sum
             reference = filename
-        obj.add_object(object_type,
-                       value,
-                       source,
-                       method,
-                       reference,
-                       user)
+        ret = tlo.add_object(object_type, value,
+                             source, method, reference, user)
 
-        if is_validate_only == False:
-            obj.save(username=user)
-
-        new_len = len(obj.obj)
-        if new_len > cur_len:
-            if not is_validate_only:
-                results['message'] = "Object added successfully!"
-            results['success'] = True
-            if file_:
-                # do we have a pcap?
-                if data[:4] in ('\xa1\xb2\xc3\xd4',
-                                '\xd4\xc3\xb2\xa1',
-                                '\x0a\x0d\x0d\x0a'):
-                    handle_pcap_file(filename,
-                                     data,
-                                     source,
-                                     user=user,
-                                     related_id=id_,
-                                     related_type=type_)
-                else:
-                    #XXX: MongoEngine provides no direct GridFS access so we
-                    #     need to use pymongo directly.
-                    col = settings.COL_OBJECTS
-                    grid = mongo_connector("%s.files" % col)
-                    if grid.find({'md5': md5sum}).count() == 0:
-                        put_file(filename, data, collection=col)
-            if add_indicator and is_validate_only == False:
-                from crits.indicators.handlers import handle_indicator_ind
-
-                campaign = obj.campaign if hasattr(obj, 'campaign') else None
-                ind_res = handle_indicator_ind(value,
-                                               source,
-                                               object_type,
-                                               IndicatorThreatTypes.UNKNOWN,
-                                               IndicatorAttackTypes.UNKNOWN,
-                                               user,
-                                               method,
-                                               reference,
-                                               add_domain=True,
-                                               campaign=campaign,
-                                               cache=cache)
-
-                if ind_res['success']:
-                    ind = ind_res['object']
-                    forge_relationship(class_=obj,
-                                       right_class=ind,
-                                       rel_type=RelationshipTypes.RELATED_TO,
-                                       user=user,
-                                       get_rels=is_sort_relationships)
-                else:
-                    results['message'] = "Object was added, but failed to add Indicator." \
-                                         "<br>Error: " + ind_res.get('message')
-
-            if is_sort_relationships == True:
-                if file_ or add_indicator:
-                    # does this line need to be here?
-                    # obj.reload()
-                    results['relationships'] = obj.sort_relationships(user, meta=True)
-                else:
-                    results['relationships'] = obj.sort_relationships(user, meta=True)
-
+        if not ret['success']:
+            msg = '%s! [Type: "%s"][Value: "%s"]'
+            return {"success": False,
+                    "message": msg % (ret['message'], object_type, value)}
         else:
-            results['message'] = "Object already exists! [Type: " + object_type + "][Value: " + value + "] "
-            results['success'] = False
-        if (get_objects):
-            results['objects'] = obj.sort_objects()
+            results = {'success': True}
 
-        results['id'] = str(obj.id)
+        if not is_validate_only: # save the object
+            tlo.update(add_to_set__obj=ret['object'])
+            results['message'] = "Object added successfully"
+
+        if file_:
+            # do we have a pcap?
+            if data[:4] in ('\xa1\xb2\xc3\xd4',
+                            '\xd4\xc3\xb2\xa1',
+                            '\x0a\x0d\x0d\x0a'):
+                handle_pcap_file(filename,
+                                 data,
+                                 source,
+                                 user=user,
+                                 related_id=id_,
+                                 related_type=type_)
+            else:
+                #XXX: MongoEngine provides no direct GridFS access so we
+                #     need to use pymongo directly.
+                col = settings.COL_OBJECTS
+                grid = mongo_connector("%s.files" % col)
+                if grid.find({'md5': md5sum}).count() == 0:
+                    put_file(filename, data, collection=col)
+
+        if add_indicator and not is_validate_only:
+            campaign = tlo.campaign if hasattr(tlo, 'campaign') else None
+            from crits.indicators.handlers import handle_indicator_ind
+            ind_res = handle_indicator_ind(value,
+                                           source,
+                                           object_type,
+                                           IndicatorThreatTypes.UNKNOWN,
+                                           IndicatorAttackTypes.UNKNOWN,
+                                           user,
+                                           method,
+                                           reference,
+                                           add_domain=True,
+                                           campaign=campaign,
+                                           cache=cache)
+
+            if ind_res['success']:
+                forge_relationship(class_=tlo,
+                                   right_class=ind_res['object'],
+                                   rel_type=RelationshipTypes.RELATED_TO,
+                                   user=user)
+            else:
+                msg = "Object added, but failed to add Indicator.<br>Error: %s"
+                results['message'] = msg % ind_res.get('message')
+
+        if is_sort_relationships == True:
+            results['relationships'] = tlo.sort_relationships(user, meta=True)
+
+        if get_objects:
+            results['objects'] = tlo.sort_objects()
+
+        results['id'] = str(tlo.id)
         return results
-    except ValidationError, e:
-        return {'success': False,
-                'message': str(e)}
+    except ValidationError as e:
+        return {'success': False, 'message': str(e)}
 
 def delete_object_file(value):
     """

--- a/extras/www/static/js/bulk_add_default.js
+++ b/extras/www/static/js/bulk_add_default.js
@@ -784,7 +784,7 @@ function parseFailedResults(result, table, errors, isShowIcons)
     }
 }
 
-function parseSuccessfulResults(result, table, progress, isShowIcons, linkData) {
+function parseSuccessfulResults(result, table, progress, isShowIcons, linkData, messages) {
 
     var linkColumnIndex = getColumnIndexFromName(table, LINK_COLUMN_NAME);
 
@@ -798,6 +798,7 @@ function parseSuccessfulResults(result, table, progress, isShowIcons, linkData) 
                 createLiStatusElement(progress.find('#duplicates'), result.successfulRows[thisRow].message, offsetRow, -1, isShowIcons);
             } else {
                 createLiStatusElement(progress.find('#messages'), result.successfulRows[thisRow].message, offsetRow, -1, false);
+                messages.append(result.successfulRows[thisRow].message + '<br>');
             }
         }
 
@@ -843,7 +844,7 @@ function parseResults(result, table, progress, errors, isValidateOnly, offset, i
 
     appendSummary(result, isValidateOnly, progress.find('#messages'), errors, progress);
     parseFailedResults(result, table, errors, isShowIcons);
-    parseSuccessfulResults(result, table, progress, isShowIcons, linkData);
+    parseSuccessfulResults(result, table, progress, isShowIcons, linkData, errors);
 
     updateResultsCounts(progress);
 


### PR DESCRIPTION
Bulk uploading large quantities of Objects was taking an extremely long time, especially when the "Add Indicator" option was selected. I found that a huge portion of the time was spent saving the entire TLO back to the DB after adding the Object, and then again after adding the relationship to the Indicator.  As more and more Objects/Relationships are added, the document takes even longer to write to the DB. By using `TLO.update(add_to_set__xxxx=xxxx)` to insert the new object/relationship, rather than `TLO.save()`, uploading a sample set of 100 objects (and adding Indicators for each) took ~10% as long to complete. 

I think there may be additional performance improvements by caching the database writes until each block of 50 objects have been processed, but the solution in this PR is a good start and also noticeably improves performance when adding a single relationship or object to any TLO with a very large number of relationships or objects.