### PR TITLE
Fix TLO Download functionality

### DIFF
--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -93,9 +93,9 @@ def create_zip(files, pw_protect=True):
         from crits.config.config import CRITsConfig
         crits_config = CRITsConfig.objects().first()
         if crits_config:
-            zip7_password = crits_config.zip7_password
+            zip7_password = crits_config.zip7_password or 'infected'
         else:
-            zip7_password = settings.ZIP7_PASSWORD
+            zip7_password = settings.ZIP7_PASSWORD or 'infected'
         dumpdir = tempfile.mkdtemp() #dir=temproot
         #write out binary files
         for f in files:

--- a/crits/indicators/templates/indicator_detail.html
+++ b/crits/indicators/templates/indicator_detail.html
@@ -258,7 +258,7 @@
 <div style="display: none;">
 
 <div id="dialog-download-indicator" title="Download Indicator">
-    <form id="form-download-indicator" action='{% url "crits.core.views.download_object" %}' method="POST" enctype="multipart/form-data">
+    <form id="form-download-indicator" action='{% url "crits.core.views.download_object" %}' method="POST" enctype="multipart/form-data">{% csrf_token %}
     <table class="form">{{forms.download_form.as_table}}</table>
     </form>
 </div>

--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -1,3 +1,5 @@
+import json
+
 from mongoengine import Document
 from mongoengine import StringField, ListField
 from mongoengine import IntField
@@ -7,6 +9,8 @@ from crits.samples.migrate import migrate_sample
 from crits.core.crits_mongoengine import CritsBaseAttributes
 from crits.core.crits_mongoengine import CritsSourceDocument
 from crits.core.crits_mongoengine import CritsActionsDocument
+from crits.core.crits_mongoengine import json_handler
+from crits.core.data_tools import format_file
 from crits.core.fields import getFileField
 
 
@@ -153,3 +157,17 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
 
         if isinstance(filenames, list):
             self.filenames = filenames
+
+    def _json_yaml_convert(self, exclude=None):
+        """
+        Helper to convert to a dict before converting to JSON.
+
+        :param exclude: list of fields to exclude.
+        :type exclude: list
+        :returns: json
+        """
+
+        d = self.to_dict(exclude)
+        if 'filedata' not in exclude:
+            (d['filedata'], ext) = format_file(self.filedata.read(), 'base64')
+        return json.dumps(d, default=json_handler)


### PR DESCRIPTION
TLO download had a number of issues. Certain combinations of options were leading to a `string indices must be integers, not str` error, and certain form options that didn't result in error weren't producing expected results. 

Having an empty string in the DB for a Zip Password was also lead to an exception. This will now default to "infected" as stated in the function comments.