### PR TITLE
Allow triage of Samples with no binary

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -928,7 +928,7 @@ def handle_file(filename, data, source, method='Generic', reference='',
         sample.reload()
 
         # run sample triage:
-        if len(AnalysisResult.objects(object_id=str(sample.id))) < 1 and data:
+        if len(AnalysisResult.objects(object_id=str(sample.id))) < 1:
             run_triage(sample, user)
 
         # update relationship if a related top-level object is supplied


### PR DESCRIPTION
Binary data shouldn't be required for triage to be run on a Sample. Valuable analysis can be performed using only the Sample's metadata.  This change was originally submitted as PR #1375 of legacy, but was lost during the open source transition.