### PR TITLE
Check for "seek" attribute before seeking

### DIFF
--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -192,9 +192,10 @@ def run_service(name, type_, id_, user, obj=None,
     # Give the service a chance to check for required fields.
     try:
         service_class.valid_for(local_obj.obj)
-        if hasattr(local_obj.obj, 'filedata') and local_obj.obj.filedata:
-            # Reset back to the start so the service gets the full file.
-            local_obj.obj.filedata.seek(0)
+        if hasattr(local_obj.obj, 'filedata'):
+            if hasattr(local_obj.obj.filedata, 'seek'):
+                # Reset back to the start so the service gets the full file.
+                local_obj.obj.filedata.seek(0)
     except ServiceConfigError as e:
         result['html'] = str(e)
         return result


### PR DESCRIPTION
Occasionally `local_obj.obj.filedata` will evaluate to True, but it won't actually have the `.seek()` attribute. This prevents an exception in that case.