### PR TITLE
Fix #677

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -452,21 +452,24 @@ class CritsDocument(BaseDocument):
 
         # perform migration, if needed
         if hasattr(doc, '_meta'):
-            doc._meta['migrated'] = False
-            if doc._meta.get('needs_migration', False):
-                try:
-                    doc.migrate()
-                except Exception as e:
-                    e.tlo = doc.id
-                    raise e
-                doc._meta['migrated'] = True
+            if not doc._meta.get('migrated',False):
+                doc._meta['migrated'] = False
             if ('schema_version' in doc and
                 'latest_schema_version' in doc._meta and
                 doc.schema_version < doc._meta['latest_schema_version']):
                 # mark for migration
                 doc._meta['needs_migration'] = True
                 # reload doc to get full document from database
+            if (doc._meta.get('needs_migration', False) and
+                not doc._meta.get('migrated', False)):
+                doc._meta['migrated'] = True
                 doc.reload()
+                try:
+                    doc.migrate()
+                except Exception as e:
+                    e.tlo = doc.id
+                    raise e
+
 
         return doc
 

--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -461,11 +461,12 @@ class CritsDocument(BaseDocument):
                 doc._meta['needs_migration'] = True
                 # reload doc to get full document from database
             if (doc._meta.get('needs_migration', False) and
-                not doc._meta.get('migrated', False)):
-                doc._meta['migrated'] = True
+                not doc._meta.get('migrating', False)):
+                doc._meta['migrating'] = True
                 doc.reload()
                 try:
                     doc.migrate()
+                    doc._meta['migrated'] = True
                 except Exception as e:
                     e.tlo = doc.id
                     raise e


### PR DESCRIPTION
Load of an object from mongo with partial data would cause a schema update on partial data.  This is bad.  It is important to avoid an infinite loop on reload.