### PR TITLE
default exclude param to empty list

### DIFF
--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -158,7 +158,7 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
         if isinstance(filenames, list):
             self.filenames = filenames
 
-    def _json_yaml_convert(self, exclude=None):
+    def _json_yaml_convert(self, exclude=[]):
         """
         Helper to convert to a dict before converting to JSON.
 


### PR DESCRIPTION
Otherwise, line 171 may try to treat None as a list and crash. This has been breaking sample API searches for me.

Can someone else give this a whirl for me, just to verify that it doesn't break a thing?