### PR TITLE
Fix array params where defaulting to None

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -143,7 +143,7 @@ class CritsQuerySet(QS):
         csvout += "".join(obj.to_csv(fields) for obj in self)
         return csvout
 
-    def to_json(self, exclude=None):
+    def to_json(self, exclude=[]):
         """
         Converts a CritsQuerySet to JSON.
 
@@ -166,7 +166,7 @@ class CritsQuerySet(QS):
 
         return [self._document.from_yaml(doc) for doc in yaml_data]
 
-    def to_yaml(self, exclude=None):
+    def to_yaml(self, exclude=[]):
         """
         Converts a CritsQuerySet to a list of YAML docs.
 
@@ -584,7 +584,7 @@ class CritsDocument(BaseDocument):
             return result
         return data
 
-    def _json_yaml_convert(self, exclude=None):
+    def _json_yaml_convert(self, exclude=[]):
         """
         Helper to convert to a dict before converting to JSON.
 
@@ -610,7 +610,7 @@ class CritsDocument(BaseDocument):
 
         return cls._from_son(json_util.loads(json_data))
 
-    def to_json(self, exclude=None):
+    def to_json(self, exclude=[]):
         """
         Convert to JSON.
 
@@ -632,7 +632,7 @@ class CritsDocument(BaseDocument):
 
         return cls._from_son(yaml.load(yaml_data))
 
-    def to_yaml(self, exclude=None):
+    def to_yaml(self, exclude=[]):
         """
         Convert to JSON.
 

--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -174,6 +174,9 @@ def format_file(data, file_format):
     :returns: tuple of (<formatted_data>, <file_extension>)
     """
 
+    if data == None:
+        return ("", "")
+
     if file_format == "base64":
         import base64
         data = base64.b64encode(data)


### PR DESCRIPTION
The None type will cause a TypeError if there isn't some sort of other checking
prior to trying to use the parameter as a list

Continuation of findings from #763 