### PR TITLE
If the raw data is unicode, then it should be encoded as utf-8

### DIFF
--- a/crits/raw_data/handlers.py
+++ b/crits/raw_data/handlers.py
@@ -363,7 +363,9 @@ def handle_raw_data_file(data, source_name, user=None,
             'message':  'Data length <= 0'
         }
         return status
-
+    
+    if isinstance(data, unicode):
+        data=data.encode('utf-8')
     # generate md5 and timestamp
     md5 = hashlib.md5(data.encode('utf-8')).hexdigest()
     timestamp = datetime.datetime.now()


### PR DESCRIPTION
Otherwise it just blows up. I suppose this is just a "helper", and the right fix should be to put this at whatever is calling handle_raw_data_file(), because whatever is passed should be a string and not unicode.