### PR TITLE
Remove redundant encode

### DIFF
--- a/crits/raw_data/handlers.py
+++ b/crits/raw_data/handlers.py
@@ -367,7 +367,7 @@ def handle_raw_data_file(data, source_name, user=None,
     if isinstance(data, unicode):
         data=data.encode('utf-8')
     # generate md5 and timestamp
-    md5 = hashlib.md5(data.encode('utf-8')).hexdigest()
+    md5 = hashlib.md5(data).hexdigest()
     timestamp = datetime.datetime.now()
 
     # generate raw_data


### PR DESCRIPTION
I forgot to remove redundant encode()