### PR TITLE
Append new relationship to passed-in TLO instance

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -1804,7 +1804,10 @@ class CritsBaseAttributes(CritsDocument, CritsBaseDocument,
                 their_rel.relationship_date = my_existing_rel.relationship_date
                 their_rel.rel_confidence = my_existing_rel.rel_confidence
                 their_rel.rel_reason = my_existing_rel.rel_reason
-            rel_item.update(add_to_set__relationships=their_rel) # add new rel
+            rel_item.relationships.append(their_rel) # add to passed rel_item
+
+            # updating DB this way can be much faster than saving entire TLO
+            rel_item.update(add_to_set__relationships=their_rel)
 
         if get_rels:
             results = {'success': True,


### PR DESCRIPTION
Occasionally the passed-in TLO instance is still used after the call to add_relationship, and appending the new relationship here saves having to hit the database for a reload.