### PR TITLE
Add description field for ip_add_update()

### DIFF
--- a/crits/ips/handlers.py
+++ b/crits/ips/handlers.py
@@ -274,6 +274,7 @@ def add_new_ip(data, rowData, request, errors, is_validate_only=False, cache={})
     related_id = data.get('related_id')
     related_type = data.get('related_type')
     relationship_type = data.get('relationship_type')
+    description = data.get('description')
 
     retVal = ip_add_update(ip, ip_type,
             source=source,
@@ -290,7 +291,8 @@ def add_new_ip(data, rowData, request, errors, is_validate_only=False, cache={})
             cache=cache,
             related_id=related_id,
             related_type=related_type,
-            relationship_type=relationship_type)
+            relationship_type=relationship_type,
+            description = description)
 
     if not retVal['success']:
         errors.append(retVal.get('message'))
@@ -337,8 +339,9 @@ def add_new_ip(data, rowData, request, errors, is_validate_only=False, cache={})
 def ip_add_update(ip_address, ip_type, source=None, source_method='',
                   source_reference='', campaign=None, confidence='low',
                   analyst=None, is_add_indicator=False, indicator_reference='',
-                  bucket_list=None, ticket=None, is_validate_only=False, cache={}, 
-                  related_id=None, related_type=None, relationship_type=None):
+                  bucket_list=None, ticket=None, is_validate_only=False,
+                  cache={}, related_id=None, related_type=None,
+                  relationship_type=None, description=''):
     """
     Add/update an IP address.
 
@@ -377,6 +380,8 @@ def ip_add_update(ip_address, ip_type, source=None, source_method='',
     :type related_type: str
     :param relationship_type: Type of relationship to create.
     :type relationship_type: str
+    :param description: A description for this IP
+    :type description: str
     :returns: dict with keys:
               "success" (boolean),
               "message" (str),
@@ -409,6 +414,11 @@ def ip_add_update(ip_address, ip_type, source=None, source_method='',
 
         if cached_results != None:
             cached_results[ip_address] = ip_object
+
+    if not ip_object.description:
+        ip_object.description = description or ''
+    elif ip_object.description != description:
+        ip_object.description += "\n" + (description or '')
 
     if isinstance(source, basestring):
         source = [create_embedded_source(source,


### PR DESCRIPTION
The `ip_add_update()` handler function for IP TLOs did not support populating the IP's description field. This adds description as a parameter of that function, and also adds support in `add_new_ip()`