### PR TITLE
Prevent loading of duplicate Action form values

### DIFF
--- a/crits/core/static/js/dialogs.js
+++ b/crits/core/static/js/dialogs.js
@@ -1474,6 +1474,7 @@ var stdDialogs = {
 		       new: {open: function(e) {
                     $('#id_action_performed_date').val(timenow());
                     var sel = $('#form-add-action').find('#id_action_type');
+                    sel.children().remove();
                     if (typeof subscription_type !== "undefined") {
                         $.ajax({
                             type:'GET',

--- a/extras/www/static/js/dialogs.js
+++ b/extras/www/static/js/dialogs.js
@@ -1474,6 +1474,7 @@ var stdDialogs = {
 		       new: {open: function(e) {
                     $('#id_action_performed_date').val(timenow());
                     var sel = $('#form-add-action').find('#id_action_type');
+                    sel.children().remove();
                     if (typeof subscription_type !== "undefined") {
                         $.ajax({
                             type:'GET',


### PR DESCRIPTION
Each time a user opens the "New Action" form, the set of available Action Types are loaded into the Action Type dropdown.  If a user opens and closes the "New Action" form repeatedly, the list grows each time with duplicates.  This fix clears the contents of the Action Type dropdown before it is populated.