### PR TITLE
Refactor, cleanup, and fix Email functions

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -25,7 +25,7 @@ from django.template.loader import render_to_string
 
 from crits.campaigns.forms import CampaignForm
 from crits.config.config import CRITsConfig
-from crits.core.crits_mongoengine import json_handler, create_embedded_source
+from crits.core.crits_mongoengine import json_handler
 from crits.core.crits_mongoengine import EmbeddedCampaign
 from crits.core.data_tools import clean_dict
 from crits.core.exceptions import ZipFileError
@@ -40,6 +40,7 @@ from crits.events.event import Event
 from crits.indicators.handlers import handle_indicator_ind
 from crits.indicators.indicator import Indicator
 from crits.notifications.handlers import remove_user_from_notification
+from crits.relationships.handlers import forge_relationship
 from crits.samples.handlers import handle_file, handle_uploaded_file, mail_sample
 from crits.services.handlers import run_triage
 
@@ -455,7 +456,8 @@ def generate_email_jtable(request, option):
                                    'jtid': '%s_listing' % type_},
                                   RequestContext(request))
 
-def handle_email_fields(data, analyst, method, related_id=None, related_type=None, relationship_type=None):
+def handle_email_fields(data, analyst, method, related_id=None,
+                        related_type=None, relationship_type=None):
     """
     Take email fields and convert them into an email object.
 
@@ -535,11 +537,6 @@ def handle_email_fields(data, analyst, method, related_id=None, related_type=Non
         new_email.add_bucket_list(bucket_list, analyst)
     if ticket:
         new_email.add_ticket(ticket, analyst)
-    new_email.source = [create_embedded_source(sourcename,
-                                               reference=reference,
-                                               method=method,
-                                               analyst=analyst)]
-
     if campaign:
         ec = EmbeddedCampaign(name=campaign,
                               confidence=confidence,
@@ -548,10 +545,6 @@ def handle_email_fields(data, analyst, method, related_id=None, related_type=Non
                               date=datetime.datetime.now())
         new_email.add_campaign(ec)
 
-
-    new_email.save(username=analyst)
-
-    # Relate the email to any other object
     related_obj = None
     if related_id and related_type and relationship_type:
         related_obj = class_from_id(related_type, related_id)
@@ -560,12 +553,10 @@ def handle_email_fields(data, analyst, method, related_id=None, related_type=Non
             retVal['message'] = 'Related Object not found.'
             return retVal
 
-    if related_obj:
-        relationship_type=RelationshipTypes.inverse(relationship=relationship_type)
-        new_email.add_relationship(related_obj,
-                                          relationship_type,
-                                          analyst=analyst,
-                                          get_rels=False)
+
+    new_email.add_source(source=sourcename, method=method,
+                         reference=reference, analyst=analyst)
+
 
     try:
         new_email.save(username=analyst)
@@ -574,8 +565,16 @@ def handle_email_fields(data, analyst, method, related_id=None, related_type=Non
         result['object'] = new_email
         result['status'] = True
     except Exception, e:
-        result['reason'] = "Failed to save object.\n<br /><pre>%s</pre>" % str(e)
+        result['reason'] = "Failed to save object.\n<br /><pre>%s</pre>" % e
+        return result
 
+    # Relate the email to any other object
+    if related_obj:
+        relationship_type=RelationshipTypes.inverse(relationship=relationship_type)
+        forge_relationship(class_=new_email,
+                           right_class=related_obj,
+                           rel_type=relationship_type,
+                           user=analyst)
     return result
 
 def handle_json(data, sourcename, reference, analyst, method,
@@ -646,10 +645,8 @@ def handle_json(data, sourcename, reference, analyst, method,
 
     result['object'] = new_email
 
-    result['object'].source = [create_embedded_source(sourcename,
-                                                    reference=reference,
-                                                    method=method,
-                                                    analyst=analyst)]
+    result['object'].add_source(source=sourcename, reference=reference,
+                                method=method, analyst=analyst)
 
     try:
         result['object'].save(username=analyst)
@@ -762,10 +759,8 @@ def handle_yaml(data, sourcename, reference, analyst, method, email_id=None,
             result['reason'] = "Failed to save object.\n<br /><pre>%s</pre>" % str(e)
             return result
     else:
-        result['object'].source = [create_embedded_source(sourcename,
-                                                        reference=reference,
-                                                        method=method,
-                                                        analyst=analyst)]
+        result['object'].add_source(source=sourcename, method=method,
+                                    reference=reference, analyst=analyst)
 
         result['object'].save(username=analyst)
 
@@ -848,7 +843,8 @@ def handle_msg(data, sourcename, reference, analyst, method, password='',
                                                  fuzzy=True)
 
     obj = handle_email_fields(result['email'], analyst, method,
-                              related_id=related_id, related_type=related_type, relationship_type=relationship_type)
+                              related_id=related_id, related_type=related_type,
+                              relationship_type=relationship_type)
 
     if not obj["status"]:
         response['reason'] = obj['reason']
@@ -891,14 +887,33 @@ def handle_msg(data, sourcename, reference, analyst, method, password='',
             attach_messages.append('%s: Cannot decrypt attachment (pkcs7).' % file.get('name', ''))
     if len(attach_messages):
         response['message'] = '<br/>'.join(attach_messages)
+
+    # Relate any Attachments to the related_obj
+    related_obj = None
+    if related_id and related_type and relationship_type:
+        related_obj = class_from_id(related_type, related_id)
+        if not related_obj:
+            retVal['success'] = False
+            retVal['message'] = 'Related Object not found.'
+            return retVal
+
+        email.reload()
+        for rel in email.relationships:
+            if rel.rel_type == 'Sample':
+                forge_relationship(class_=related_obj,
+                                   right_type=rel.rel_type,
+                                   right_id=rel.object_id,
+                                   rel_type=RelationshipTypes.RELATED_TO,
+                                   user=analyst)
+
     response['status'] = True
     response['obj_id'] = obj['object'].id
     return response
 
 def handle_pasted_eml(data, sourcename, reference, analyst, method,
-                      parent_type=None, parent_id=None, campaign=None,
-                      confidence=None, bucket_list=None, ticket=None,
-                      related_id=None, related_type=None, relationship_type=None):
+                      campaign=None, confidence=None, bucket_list=None,
+                      ticket=None, related_id=None, related_type=None,
+                      relationship_type=None):
     """
     Take email in EML and convert them into an email object.
 
@@ -912,10 +927,6 @@ def handle_pasted_eml(data, sourcename, reference, analyst, method,
     :type analyst: str
     :param method: The method of acquiring this email.
     :type method: str
-    :param parent_type: The top-level object type of the parent.
-    :type parent_type: str
-    :param parent_id: The ObjectId of the parent.
-    :type parent_id: str
     :param campaign: The campaign to attribute to this email.
     :type campaign: str
     :param confidence: Confidence level of the campaign.
@@ -956,14 +967,14 @@ def handle_pasted_eml(data, sourcename, reference, analyst, method,
             line = " %s" % line
         emldata.append(line)
     emldata = "\n".join(emldata)
-    return handle_eml(emldata, sourcename, reference, analyst, method, parent_type,
-                      parent_id, campaign, confidence, bucket_list, ticket, 
-                      related_id=related_id, related_type=related_type, relationship_type=relationship_type)
+    return handle_eml(emldata, sourcename, reference, analyst, method,
+                      campaign, confidence, bucket_list, ticket,
+                      related_id, related_type, relationship_type)
 
 
-def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
-               parent_id=None, campaign=None, confidence=None, bucket_list=None,
-               ticket=None, related_id=None, related_type=None, relationship_type=None):
+def handle_eml(data, sourcename, reference, analyst, method, campaign=None,
+               confidence=None, bucket_list=None, ticket=None,
+               related_id=None, related_type=None, relationship_type=None):
     """
     Take email in EML and convert them into an email object.
 
@@ -977,10 +988,6 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
     :type analyst: str
     :param method: The method of acquiring this email.
     :type method: str
-    :param parent_type: The top-level object type of the parent.
-    :type parent_type: str
-    :param parent_id: The ObjectId of the parent.
-    :type parent_id: str
     :param campaign: The campaign to attribute to this email.
     :type campaign: str
     :param confidence: Confidence level of the campaign.
@@ -1143,10 +1150,8 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
 
     result['object'] = new_email
 
-    result['object'].source = [create_embedded_source(sourcename,
-                                                      reference=reference,
-                                                      method=method,
-                                                      analyst=analyst)]
+    result['object'].add_source(source=sourcename, reference=reference,
+                                method=method, analyst=analyst)
 
     # Save the Email first, so we can have the id to use to create
     # relationships.
@@ -1157,31 +1162,8 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
         result['object'].reload()
         run_triage(result['object'], analyst)
     except Exception, e:
-        result['reason'] = "Failed1 to save email.\n<br /><pre>" + \
-            str(e) + "</pre>"
+        result['reason'] = "Failed to save email.\n<br /><pre>%s</pre>" % e
         return result
-
-    # Relate the email back to the pcap, if it came from PCAP.
-    if parent_id and parent_type:
-        rel_item = class_from_id(parent_type, parent_id)
-        if rel_item:
-            rel_type = RelationshipTypes.CONTAINED_WITHIN
-            ret = result['object'].add_relationship(rel_item,
-                                                    rel_type,
-                                                    analyst=analyst,
-                                                    get_rels=False)
-            if not ret['success']:
-                result['reason'] = "Failed to create relationship.\n<br /><pre>"
-                + result['message'] + "</pre>"
-            return result
-
-        # Save the email again since it now has a new relationship.
-        try:
-            result['object'].save(username=analyst)
-        except Exception, e:
-            result['reason'] = "Failed to save email.\n<br /><pre>"
-            + str(e) + "</pre>"
-            return result
 
     # Relate the email to any other object
     related_obj = None
@@ -1192,41 +1174,47 @@ def handle_eml(data, sourcename, reference, analyst, method, parent_type=None,
             retVal['message'] = 'Related Object not found.'
             return retVal
 
-    if related_obj:
-        relationship_type=RelationshipTypes.inverse(relationship=relationship_type)
-        result['object'].add_relationship(related_obj,
-                                          relationship_type,
-                                          analyst=analyst,
-                                          get_rels=False)
-        #result['object'].save(username=analyst)
+        rel_type=RelationshipTypes.inverse(relationship=relationship_type)
+        ret = result['object'].add_relationship(related_obj,
+                                                rel_type,
+                                                analyst=analyst)
+        if not ret['success']:
+            msg = "Failed to create relationship.\n<br /><pre>%s</pre>"
+            result['reason'] = msg % ret['message']
+            return result
 
         # Save the email again since it now has a new relationship.
         try:
             result['object'].save(username=analyst)
         except Exception, e:
-            result['reason'] = "Failed to save email.\n<br /><pre>"
-            + str(e) + "</pre>"
+            result['reason'] = "Failed to save email.\n<br /><pre>%s</pre>" % e
             return result
-
 
     for (md5_, attachment) in result['attachments'].items():
-        if handle_file(attachment['filename'],
-                       attachment['blob'],
-                       sourcename,
-                       method='eml_processor',
-                       reference=reference,
-                       related_id=result['object'].id,
-                       user=analyst,
-                       md5_digest=md5_,
-                       related_type='Email',
-                       campaign=campaign,
-                       confidence=confidence,
-                       bucket_list=bucket_list,
-                       ticket=ticket,
-                       relationship=RelationshipTypes.CONTAINED_WITHIN) == None:
-            result['reason'] = "Failed to save attachment.\n<br /><pre>"
-            + md5_ + "</pre>"
+        ret = handle_file(attachment['filename'],
+                          attachment['blob'],
+                          new_email.source,
+                          related_id=result['object'].id,
+                          user=analyst,
+                          md5_digest=md5_,
+                          related_type='Email',
+                          campaign=new_email.campaign,
+                          confidence=confidence,
+                          bucket_list=bucket_list,
+                          ticket=ticket,
+                          relationship=RelationshipTypes.CONTAINED_WITHIN,
+                          is_return_only_md5=False)
+        if not ret['success']:
+            msg = "Failed to save attachment '%s'.\n<br /><pre>%s</pre>"
+            result['reason'] = msg % (md5_, ret['message'])
             return result
+
+        # Also relate the attachment to the related TLO
+        if related_obj:
+            forge_relationship(class_=related_obj,
+                               right_class=ret['object'],
+                               rel_type=RelationshipTypes.RELATED_TO,
+                               user=analyst)
 
     result['status'] = True
     return result

--- a/crits/events/templates/event_detail.html
+++ b/crits/events/templates/event_detail.html
@@ -22,7 +22,7 @@
 <div id="details_section">
     <span class="horizontal_menu">
         <ul class="hmenu">
-            <li><a href="#" class="dialogClick" dialog="new-sample" persona="related" action="{% url 'crits.events.views.upload_sample' event.id %}">Add Sample</a></li>
+            <li><a href="#" class="dialogClick" dialog="new-sample" persona="related">Add Sample</a></li>
             <li><a href="#" class="dialogClick" dialog="download-event">Download Event</a></li>
             {% if admin %}
                 <li class="right"><a href="#" class="deleteClick" data-is-object="true" type="event" action='{% url "crits.events.views.remove_event" event.id %}'>Delete Event</a></li>

--- a/crits/events/urls.py
+++ b/crits/events/urls.py
@@ -4,7 +4,6 @@ urlpatterns = [
     url(r'^details/(?P<eventid>\w+)/$', 'view_event', prefix='crits.events.views'),
     url(r'^add/$', 'add_event', prefix='crits.events.views'),
     url(r'^search/$', 'event_search', prefix='crits.events.views'),
-    url(r'^upload/sample/(?P<event_id>\w+)/$', 'upload_sample', prefix='crits.events.views'),
     url(r'^remove/(?P<_id>[\S ]+)$', 'remove_event', prefix='crits.events.views'),
     url(r'^set_title/(?P<event_id>\w+)/$', 'set_event_title', prefix='crits.events.views'),
     url(r'^set_type/(?P<event_id>\w+)/$', 'set_event_type', prefix='crits.events.views'),

--- a/crits/events/views.py
+++ b/crits/events/views.py
@@ -118,49 +118,6 @@ def view_event(request, eventid):
                               RequestContext(request))
 
 
-@user_passes_test(user_can_view_data)
-def upload_sample(request, event_id):
-    """
-    Upload a sample to associate with this event.
-
-    :param request: Django request object (Required)
-    :type request: :class:`django.http.HttpRequest`
-    :param event_id: The ObjectId of the event to associate with this sample.
-    :type event_id: str
-    :returns: :class:`django.http.HttpResponse`, :class:`django.http.HttpResponse`
-    """
-
-    if request.method == 'POST':    # and request.is_ajax():
-        form = UploadFileForm(request.user, request.POST, request.FILES)
-        if form.is_valid():
-            email = None
-            if request.POST.get('email'):
-                email = request.user.email
-
-            result = add_sample_for_event(event_id,
-                                          form.cleaned_data,
-                                          request.user.username,
-                                          request.FILES.get('filedata', None),
-                                          request.POST.get('filename', None),
-                                          request.POST.get('md5', None),
-                                          email,
-                                          form.cleaned_data['inherit_sources'])
-            if result['success']:
-                result['redirect_url'] = reverse('crits.events.views.view_event', args=[event_id])
-            return render_to_response('file_upload_response.html',
-                                      {'response': json.dumps(result)},
-                                      RequestContext(request))
-        else:
-            form.fields['related_md5'].widget = forms.HiddenInput() #hide field so it doesn't reappear
-            return render_to_response('file_upload_response.html',
-                                      {'response': json.dumps({'success': False,
-                                                               'form': form.as_table()})},
-                                      RequestContext(request))
-    else:
-        return HttpResponseRedirect(reverse('crits.events.views.view_event',
-                                            args=[event_id]))
-
-
 @user_passes_test(user_is_admin)
 def remove_event(request, _id):
     """


### PR DESCRIPTION
The EML handle functions still had parent id/type parameters, and the Add Sample button on Events used an upload_sample function, that had both been effectively replaced by the general Add Related TLO functionality, so it made sense to remove them.  In the process I fixed an issue with the Indicator Blob/CSV upload, and made the email functions more consistent with each other.  While I was at it, I tried to make things respect the PEP8 79 character limit.