### PR TITLE
If someone uploads a PCAP as a sample, detect it and DTRT.

### DIFF
--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -70,7 +70,7 @@ def create_zip(files, pw_protect=True):
     Create a zip file. Creates a temporary directory to write files to on disk
     using :class:`tempfile`. Uses /usr/bin/zip as the zipping mechanism
     currently. Will password protect the zip file as a default. The password for
-    the zip file defaults to "infected", but it can be changed in the config 
+    the zip file defaults to "infected", but it can be changed in the config
     under zip7_password.
 
     :param files: The files to add to the zip file.
@@ -660,3 +660,24 @@ def validate_sha256_checksum(sha256_checksum):
         retVal['success'] = False
 
     return retVal
+
+def detect_pcap(data):
+    """
+    Detect if the data has the magic numbers for a PCAP.
+
+    :param data: The data to inspect.
+    :type data: str
+    :returns: bool
+    """
+
+    magic = ''.join(x.encode('hex') for x in data[:4])
+    if magic in (
+        'a1b2c3d4', #identical
+        'd4c3b2a1', #swapped
+        '4d3cb2a1',
+        'a1b23c4d', #nanosecond resolution
+        '0a0d0d0a', #pcap-ng
+    ):
+        return True
+    else:
+        return False

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from crits.core import form_consts
 from crits.core.class_mapper import class_from_id, class_from_type
-from crits.core.data_tools import convert_string_to_bool
+from crits.core.data_tools import convert_string_to_bool, detect_pcap
 from crits.core.handsontable_tools import form_to_dict, get_field_from_label
 from crits.core.mongo_tools import put_file, mongo_connector
 from crits.core.user_tools import get_user_organization
@@ -281,9 +281,7 @@ def add_object(type_, id_, object_type, source, method, reference, user,
 
         if file_:
             # do we have a pcap?
-            if data[:4] in ('\xa1\xb2\xc3\xd4',
-                            '\xd4\xc3\xb2\xa1',
-                            '\x0a\x0d\x0d\x0a'):
+            if detect_pcap(data):
                 handle_pcap_file(filename,
                                  data,
                                  source,

--- a/crits/pcaps/views.py
+++ b/crits/pcaps/views.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.auth.decorators import user_passes_test
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 

--- a/crits/samples/templates/samples_uploadList.html
+++ b/crits/samples/templates/samples_uploadList.html
@@ -17,6 +17,7 @@
             <tr>
                 <td class="key">Filename</td>
                 <td><a href="{% url 'crits.samples.views.detail' s %}">{{ s }}</a></td>
+                <td>In the event this was a PCAP: <a href="{% url 'crits.pcaps.views.pcap_details' s %}">{{ s }}</a></td>
             </tr>
         {% endfor %}
         </tbody>

--- a/crits/samples/views.py
+++ b/crits/samples/views.py
@@ -291,24 +291,16 @@ def upload_file(request, related_md5=None):
                                 'message': message }
                     md5_response = result
                 elif len(result) == 1:
-                    md5_response = None
-                    if not request.FILES:
-                        response['success'] = result[0].get('success', False)
-                        if(response['success'] == False):
-                            response['message'] = result[0].get('message', response.get('message'))
-                        else:
-                            md5_response = [result[0].get('object').md5]
-                    else:
-                        md5_response = [result[0]]
-                        response['success'] = True
-
-                    if md5_response != None:
-                        response['message'] = ('File uploaded successfully. <a href="%s">View Sample.</a>'
-                                               % reverse('crits.samples.views.detail',
-                                                         args=md5_response))
+                    response['success'] = result[0].get('success', False)
+                    response['message'] = result[0].get('message',
+                                                        response.get('message'))
+                    try:
+                        md5_response = [result[0].get('object').md5]
+                    except:
+                        md5_response = None
 
                 if response['success']:
-                    if request.POST.get('email'):
+                    if request.POST.get('email') and md5_response:
                         for s in md5_response:
                             email_errmsg = mail_sample(s, [request.user.email])
                             if email_errmsg is not None:


### PR DESCRIPTION
This is really rough code as the sample uploading code is a freaking
mess. This will allow for a single PCAP to be uploaded or a set of PCAPs
in a zip, or theoretically a zip containing both samples and PCAPs. It
will detect the PCAP by magic number and upload it as a PCAP instead. In
bulk situations it will return just the MD5 of the PCAP. This makes it
hard to determine in the upload list whether it was a sample or a PCAP,
so for now there are links to both details pages, so if it's a sample or
PCAP one of the links will work.

This also exposed some issues where the good informational messages in
Sample uploading was being masked by a default message. This was fixed
but caused other errors. I hope those were fixed in this.