### PR TITLE
Potential Improvements to Attack/Threat Type Lists

### DIFF
--- a/crits/indicators/indicator.py
+++ b/crits/indicators/indicator.py
@@ -260,7 +260,7 @@ class Indicator(CritsBaseAttributes, CritsActionsDocument, CritsSourceDocument, 
         parsed_threat_types = [s.strip() for s in parsed_threat_types]
 
         unknown = IndicatorThreatTypes.UNKNOWN
-        if len(self.threat_types) and unknown in parsed_threat_types:
+        if len(self.threat_types) and unknown in parsed_threat_types and append:
             parsed_threat_types.remove(unknown)
         if unknown in self.threat_types:
             self.threat_types.remove(unknown)

--- a/crits/indicators/static/js/indicators.js
+++ b/crits/indicators/static/js/indicators.js
@@ -173,18 +173,20 @@ $(document).ready(function() {
                 return false;
             }
         },
-        beforeTagRemoved: function(event, ui) {
-            var my_threat_types = $("#threat_type_list").tagit("assignedTags");
-            if (my_threat_types.length <= 1) {
-                return false;
-            }
-        },
         afterTagAdded: function(event, ui) {
-            var my_threat_types = $("#threat_type_list").tagit("assignedTags");
-            update_threat_types(my_threat_types);
+            var my_threats = $("#threat_type_list").tagit("assignedTags");
+            if (my_threats.length > 1 && my_threats.indexOf("Unknown") > -1) {
+                $("#threat_type_list").tagit("removeTagByLabel", "Unknown");
+            }
+            else {
+                update_threat_types(my_threats);
+            }
         },
         afterTagRemoved: function(event, ui) {
             var my_threat_types = $("#threat_type_list").tagit("assignedTags");
+            if (my_threat_types.length < 1) {
+                $("#threat_type_list").tagit("createTag", "Unknown");
+            }
             update_threat_types(my_threat_types);
         },
         onTagClicked: function(event, ui) {
@@ -200,7 +202,10 @@ $(document).ready(function() {
                 data: {},
                 datatype: 'json',
                 success: function(data) {
-                    available_threat_types = tmp = data;
+                    available_threat_types = data;
+                    tmp = data.filter(function(i) {
+	                    return i != "Unknown"
+                    });
                 }
             });
             return tmp;
@@ -223,18 +228,20 @@ $(document).ready(function() {
                 return false;
             }
         },
-        beforeTagRemoved: function(event, ui) {
-            var my_attack_types = $("#attack_type_list").tagit("assignedTags");
-            if (my_attack_types.length <= 1) {
-                return false;
-            }
-        },
         afterTagAdded: function(event, ui) {
-            var my_attack_types = $("#attack_type_list").tagit("assignedTags");
-            update_attack_types(my_attack_types);
+            var my_attacks = $("#attack_type_list").tagit("assignedTags");
+            if (my_attacks.length > 1 && my_attacks.indexOf("Unknown") > -1) {
+                $("#attack_type_list").tagit("removeTagByLabel", "Unknown");
+            }
+            else {
+                update_attack_types(my_attacks);
+            }
         },
         afterTagRemoved: function(event, ui) {
             var my_attack_types = $("#attack_type_list").tagit("assignedTags");
+            if (my_attack_types.length < 1) {
+                $("#attack_type_list").tagit("createTag", "Unknown");
+            }
             update_attack_types(my_attack_types);
         },
         onTagClicked: function(event, ui) {
@@ -250,7 +257,10 @@ $(document).ready(function() {
                 data: {},
                 datatype: 'json',
                 success: function(data) {
-                    available_attack_types = tmp = data;
+                    available_attack_types = data;
+                    tmp = data.filter(function(i) {
+	                    return i != "Unknown"
+                    });
                 }
             });
             return tmp;

--- a/extras/www/static/js/indicators.js
+++ b/extras/www/static/js/indicators.js
@@ -173,18 +173,20 @@ $(document).ready(function() {
                 return false;
             }
         },
-        beforeTagRemoved: function(event, ui) {
-            var my_threat_types = $("#threat_type_list").tagit("assignedTags");
-            if (my_threat_types.length <= 1) {
-                return false;
-            }
-        },
         afterTagAdded: function(event, ui) {
-            var my_threat_types = $("#threat_type_list").tagit("assignedTags");
-            update_threat_types(my_threat_types);
+            var my_threats = $("#threat_type_list").tagit("assignedTags");
+            if (my_threats.length > 1 && my_threats.indexOf("Unknown") > -1) {
+                $("#threat_type_list").tagit("removeTagByLabel", "Unknown");
+            }
+            else {
+                update_threat_types(my_threats);
+            }
         },
         afterTagRemoved: function(event, ui) {
             var my_threat_types = $("#threat_type_list").tagit("assignedTags");
+            if (my_threat_types.length < 1) {
+                $("#threat_type_list").tagit("createTag", "Unknown");
+            }
             update_threat_types(my_threat_types);
         },
         onTagClicked: function(event, ui) {
@@ -200,7 +202,10 @@ $(document).ready(function() {
                 data: {},
                 datatype: 'json',
                 success: function(data) {
-                    available_threat_types = tmp = data;
+                    available_threat_types = data;
+                    tmp = data.filter(function(i) {
+	                    return i != "Unknown"
+                    });
                 }
             });
             return tmp;
@@ -223,18 +228,20 @@ $(document).ready(function() {
                 return false;
             }
         },
-        beforeTagRemoved: function(event, ui) {
-            var my_attack_types = $("#attack_type_list").tagit("assignedTags");
-            if (my_attack_types.length <= 1) {
-                return false;
-            }
-        },
         afterTagAdded: function(event, ui) {
-            var my_attack_types = $("#attack_type_list").tagit("assignedTags");
-            update_attack_types(my_attack_types);
+            var my_attacks = $("#attack_type_list").tagit("assignedTags");
+            if (my_attacks.length > 1 && my_attacks.indexOf("Unknown") > -1) {
+                $("#attack_type_list").tagit("removeTagByLabel", "Unknown");
+            }
+            else {
+                update_attack_types(my_attacks);
+            }
         },
         afterTagRemoved: function(event, ui) {
             var my_attack_types = $("#attack_type_list").tagit("assignedTags");
+            if (my_attack_types.length < 1) {
+                $("#attack_type_list").tagit("createTag", "Unknown");
+            }
             update_attack_types(my_attack_types);
         },
         onTagClicked: function(event, ui) {
@@ -250,7 +257,10 @@ $(document).ready(function() {
                 data: {},
                 datatype: 'json',
                 success: function(data) {
-                    available_attack_types = tmp = data;
+                    available_attack_types = data;
+                    tmp = data.filter(function(i) {
+	                    return i != "Unknown"
+                    });
                 }
             });
             return tmp;


### PR DESCRIPTION
Rather than simply restricting removal of the last item in the list, when the user attempts to remove the last item, this will replace that last item with the `Unknown` option.
Also, if a user manually adds an item to the list in the Indicator Details view, this will automatically remove `Unknown` if it exists.  Previously this functionality only worked when adding from the Add Indicator form.
Further, this removes `Unknown` as an option in the suggestions list, but still allows it to exist as the only item in a list.
Used the `append` parameter to determine whether `Unknown` should be removed from an update to the list.

@mgoffin: Curious what you think about these changes. I think they are a little better for the user, but still fit with your vision.