### PR TITLE
Fix Missing Line Change for Attack Type List

### DIFF
--- a/crits/indicators/indicator.py
+++ b/crits/indicators/indicator.py
@@ -308,7 +308,7 @@ class Indicator(CritsBaseAttributes, CritsActionsDocument, CritsSourceDocument, 
         parsed_attack_types = [s.strip() for s in parsed_attack_types]
 
         unknown = IndicatorAttackTypes.UNKNOWN
-        if len(self.attack_types) and unknown in parsed_attack_types:
+        if len(self.attack_types) and unknown in parsed_attack_types and append:
             parsed_attack_types.remove(unknown)
         if unknown in self.attack_types:
             self.attack_types.remove(unknown)


### PR DESCRIPTION
I somehow did not include a change for Attack Type that I had made for Threat Type. This should fix that.  Without this change, if you remove the last item in the Attack Type list, it will appear that the last item was replaced with `Unknown`, but if you check the DB, it won't actually have been replaced.