### PR TITLE
Vocabulary API Resource

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -751,3 +751,21 @@ def determine_format(request, serializer, default_format='application/json'):
 
     # No valid 'Accept' header/formats. Sane default.
     return default_format
+
+
+class MongoObject(object):
+    """Class that represents a Mongo-like object"""
+    def __init__(self, initial=None):
+        self.__dict__['_data'] = {}
+
+        if hasattr(initial, 'items'):
+            self.__dict__['_data'] = initial
+
+    def __getattr__(self, name):
+        return self._data.get(name, None)
+
+    def __setattr__(self, name, value):
+        self.__dict__['_data'][name] = value
+
+    def to_dict(self):
+        return self._data

--- a/crits/urls.py
+++ b/crits/urls.py
@@ -59,6 +59,7 @@ if settings.ENABLE_API:
     from crits.services.api import ServiceResource
     from crits.signatures.api import SignatureResource
     from crits.targets.api import TargetResource
+    from crits.vocabulary.api import VocabResource
 
     v1_api = Api(api_name='v1')
     v1_api.register(ActorResource())
@@ -81,6 +82,7 @@ if settings.ENABLE_API:
     v1_api.register(ServiceResource())
     v1_api.register(SignatureResource())
     v1_api.register(TargetResource())
+    v1_api.register(VocabResource())
 
     for service_directory in settings.SERVICE_DIRS:
         if os.path.isdir(service_directory):

--- a/crits/vocabulary/api.py
+++ b/crits/vocabulary/api.py
@@ -1,0 +1,60 @@
+from tastypie import authorization, fields, http
+from tastypie.authentication import MultiAuthentication
+from tastypie.exceptions import ImmediateHttpResponse
+from tastypie_mongoengine.resources import MongoEngineResource
+
+from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
+from crits.core.api import CRITsSerializer, CRITsAPIResource, MongoObject
+from crits.vocabulary.actors import ThreatTypes, Motivations
+from crits.vocabulary.actors import Sophistications, IntendedEffects
+from crits.vocabulary.confidence import Confidence
+from crits.vocabulary.events import EventTypes
+from crits.vocabulary.indicators import IndicatorTypes, IndicatorThreatTypes
+from crits.vocabulary.indicators import IndicatorAttackTypes, IndicatorCI
+from crits.vocabulary.ips import IPTypes
+from crits.vocabulary.kill_chain import KillChain
+from crits.vocabulary.objects import ObjectTypes
+from crits.vocabulary.relationships import RelationshipTypes
+from crits.vocabulary.sectors import Sectors
+from crits.vocabulary.status import Status
+
+class VocabResource(MongoEngineResource):
+    """
+    Class to handle everything related to the Vocabulary API.
+
+    Currently supports GET.
+    """
+
+    category = fields.CharField(attribute="category")
+    values = fields.ListField(attribute="values")
+
+    class Meta:
+        allowed_methods = ('get')
+        resource_name = "vocab"
+        authentication = MultiAuthentication(CRITsApiKeyAuthentication(),
+                                             CRITsSessionAuthentication())
+        authorization = authorization.Authorization()
+
+    def obj_get_list(self, bundle=None, **kwargs):
+        output = []
+        vocab_classes = (ThreatTypes, Motivations, Sophistications,
+                         IntendedEffects, Confidence, EventTypes,
+                         IndicatorTypes, IndicatorThreatTypes,
+                         IndicatorAttackTypes, IndicatorCI, IPTypes, KillChain,
+                         ObjectTypes, RelationshipTypes, Sectors, Status)
+        for class_ in vocab_classes:
+            values = class_.values(sort=True)
+            output.append(MongoObject(initial={'category': class_.__name__,
+                                               'values': values}))
+        return output
+
+    def obj_get(self, bundle=None, **kwargs):
+        category = kwargs['pk']
+        try:
+            class_ = globals()[category]
+        except:
+            msg = 'Vocabulary category "%s" does not exist' % category
+            raise ImmediateHttpResponse(response=http.HttpBadRequest(msg))
+
+        values = class_.values(sort=True)
+        return MongoObject(initial={'category': category, 'values': values})

--- a/crits/vocabulary/api.py
+++ b/crits/vocabulary/api.py
@@ -1,10 +1,9 @@
 from tastypie import authorization, fields, http
 from tastypie.authentication import MultiAuthentication
 from tastypie.exceptions import ImmediateHttpResponse
-from tastypie_mongoengine.resources import MongoEngineResource
 
 from crits.core.api import CRITsApiKeyAuthentication, CRITsSessionAuthentication
-from crits.core.api import CRITsSerializer, CRITsAPIResource, MongoObject
+from crits.core.api import CRITsAPIResource, MongoObject
 from crits.vocabulary.actors import ThreatTypes, Motivations
 from crits.vocabulary.actors import Sophistications, IntendedEffects
 from crits.vocabulary.confidence import Confidence
@@ -18,7 +17,7 @@ from crits.vocabulary.relationships import RelationshipTypes
 from crits.vocabulary.sectors import Sectors
 from crits.vocabulary.status import Status
 
-class VocabResource(MongoEngineResource):
+class VocabResource(CRITsAPIResource):
     """
     Class to handle everything related to the Vocabulary API.
 


### PR DESCRIPTION
This is an API resource that I created awhile ago to provide programmatic access to each CRITs vocabulary set.  We had a need to be able to pull the list of Indicator Types, in particular, so while I was at it, I made all of the vocabulary sets available.  It's not perfect, but gets the job done.  Figure I'd throw it out there so people could take a look at it.

The following URL path will return every vocabulary set:
`/api/v1/vocab/`

Providing a vocabulary class name, like below, will only return that particular set:
`/api/v1/vocab/IndicatorTypes/`