### PR TITLE
two small index fixes

### DIFF
--- a/crits/core/management/commands/create_indexes.py
+++ b/crits/core/management/commands/create_indexes.py
@@ -186,6 +186,7 @@ def create_indexes():
     samples.ensure_index("sha1", background=True)
     samples.ensure_index("sha256", background=True)
     samples.ensure_index("ssdeep", background=True)
+    samples.ensure_index("impfuzzy", background=True)
     samples.ensure_index("mimetype", background=True)
     samples.ensure_index("filetype", background=True)
     samples.ensure_index("size", background=True)

--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -64,7 +64,7 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
                          'linked_fields': ["filename", "source", "campaign",
                                            "filetype"],
                          'details_link': 'details',
-                         'no_sort': ['details', 'id']
+                         'no_sort': ['details']
                        },
     }
 


### PR DESCRIPTION
1) impfuzzy should have an index just like ssdeep
2) Samples listing didn't allow to sort by "Store ID", the index is in place for this, and all the other TLOs are doing it