### PR TITLE
Fix '/img/' Web Server Alias

### DIFF
--- a/extras/httpd.conf
+++ b/extras/httpd.conf
@@ -4,7 +4,7 @@ Alias /js/ /data/crits/extras/www/js/
 Alias /css/ /data/crits/extras/www/css/
 Alias /ext/ /data/crits/extras/www/ext/
 Alias /images/ /data/crits/extras/www/images/
-Alias /img/ /data/crits/extras/www/images/
+Alias /img/ /data/crits/extras/www/img/
 Alias /new_images/ /data/crits/extras/www/new_images/
 Alias /plugin/ /data/crits/extras/www/plugin/
 Alias /favicon.ico /data/crits/extras/www/favicon.ico

--- a/extras/rhel_ssl.conf
+++ b/extras/rhel_ssl.conf
@@ -39,7 +39,7 @@ Alias /js/ /data/crits/extras/www/js/
 Alias /css/ /data/crits/extras/www/css/
 Alias /ext/ /data/crits/extras/www/ext/
 Alias /images/ /data/crits/extras/www/images/
-Alias /img/ /data/crits/extras/www/images/
+Alias /img/ /data/crits/extras/www/img/
 Alias /new_images/ /data/crits/extras/www/new_images/
 Alias /plugin/ /data/crits/extras/www/plugin/
 Alias /favicon.ico /data/crits/extras/www/favicon.ico

--- a/extras/sites-available/default-ssl
+++ b/extras/sites-available/default-ssl
@@ -16,7 +16,7 @@
     Alias /css/ /data/crits/extras/www/css/
     Alias /ext/ /data/crits/extras/www/ext/
     Alias /images/ /data/crits/extras/www/images/
-    Alias /img/ /data/crits/extras/www/images/
+    Alias /img/ /data/crits/extras/www/img/
     Alias /new_images/ /data/crits/extras/www/new_images/
     Alias /plugin/ /data/crits/extras/www/plugin/
     Alias /favicon.ico /data/crits/extras/www/favicon.ico


### PR DESCRIPTION
I was getting errors stating that various files in `/data/crits/extras/www/img/` could not be found. I think the problem stemmed from a typo in these example files, so I thought I should fix them up.  Of course, let me know if I'm missing something here.