### PR TITLE
This fixes an issue with editing/deleting actions.

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -743,18 +743,20 @@ class CritsActionsDocument(BaseDocument):
             ea.date = date
         self.actions.append(ea)
 
-    def delete_action(self, date=None):
+    def delete_action(self, date=None, action=None):
         """
         Delete an action.
 
         :param date: The date of the action to delete.
         :type date: datetime.datetime
+        :param action: The action to delete.
+        :type action: str
         """
 
-        if not date:
+        if not date or not action:
             return
         for t in self.actions:
-            if t.date == date:
+            if t.date == date and t.action_type == action:
                 self.actions.remove(t)
                 break
 
@@ -784,7 +786,7 @@ class CritsActionsDocument(BaseDocument):
         if not date:
             return
         for t in self.actions:
-            if t.date == date:
+            if t.date == date and t.action_type == type_:
                 self.actions.remove(t)
                 ea = EmbeddedAction()
                 ea.action_type = type_

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -108,13 +108,13 @@ def action_add(type_, id_, tlo_action, user=None, **kwargs):
                        tlo_action['end_date'],
                        tlo_action['performed_date'],
                        tlo_action['reason'],
-                       tlo_action['date'])
+                       date = datetime.datetime.now())
         obj.save(username=user)
         return {'success': True, 'object': tlo_action}
     except (ValidationError, TypeError, KeyError), e:
         return {'success': False, 'message': e}
 
-def action_remove(type_, id_, date, user, **kwargs):
+def action_remove(type_, id_, date, action, user, **kwargs):
     """
     Remove an action from a TLO.
 
@@ -124,6 +124,8 @@ def action_remove(type_, id_, date, user, **kwargs):
     :type id_: str
     :param date: The date of the action to remove.
     :type date: datetime.datetime
+    :param action: The name of the action to remove.
+    :type action: str
     :param analyst: The user removing the action.
     :type analyst: str
     :returns: dict with keys "success" (boolean) and "message" (str) if failed.
@@ -143,7 +145,7 @@ def action_remove(type_, id_, date, user, **kwargs):
                 'message': 'Could not find TLO'}
     try:
         date = datetime_parser(date)
-        obj.delete_action(date)
+        obj.delete_action(date, action)
         obj.save(username=user)
         return {'success': True}
     except (ValidationError, TypeError), e:
@@ -3386,7 +3388,7 @@ def user_login(request, user):
     SESSION_KEY = '_auth_user_id'
     BACKEND_SESSION_KEY = '_auth_user_backend'
     HASH_SESSION_KEY = '_auth_user_hash'
-    REDIRECT_FIELD_NAME = 'next'
+    #REDIRECT_FIELD_NAME = 'next'
     session_auth_hash = ''
     if user is None:
         user = request.user

--- a/crits/core/static/js/dialogs.js
+++ b/crits/core/static/js/dialogs.js
@@ -691,6 +691,11 @@ function addEditSubmit(e) {
     }
     var form = dialog.find("form");
 
+    var sel = form.find('#id_action_type');
+    if (typeof sel !== "undefined") {
+        sel.attr('disabled', false);
+    }
+
     var type = form.attr('item-type');
     if (!type)
     log("Form (" + form.attr('id') + ") should have a defined item-type");
@@ -917,6 +922,7 @@ function update_dialog(e) {
                         sel.append($('<option></option>').val(y).html(y));
                     });
                     sel.find('option[value="' + sel_val + '"]').attr('selected', true);
+                    sel.attr('disabled', true);
                 }
             });
         }

--- a/crits/core/templates/action_row_widget.html
+++ b/crits/core/templates/action_row_widget.html
@@ -10,7 +10,7 @@
     <td data-field="analyst">{{action.analyst}}</td>
     <td>
     {% if admin %}
-    <a href="#" title="Delete Action" class="ui-icon ui-icon-close deleteClick" type="action" action="{% url 'crits.core.views.remove_action' obj_type=obj_type obj_id=obj_id %}" key="{{action.date}}"></a>
+    <a href="#" title="Delete Action" class="ui-icon ui-icon-close deleteClick" type="action" action="{% url 'crits.core.views.remove_action' obj_type=obj_type obj_id=obj_id %}" key="{{action.date}},{{action.action_type}}"></a>
     {% endif %}
     <a href="#" title="Edit Action" class="edit_action_button ui-icon ui-icon-pencil dialogClick" dialog="add-action" persona="update" action="{% url 'crits.core.views.add_update_action' 'update' obj_type obj_id %}"></a>
     </td>

--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -2255,10 +2255,11 @@ def remove_action(request, obj_type, obj_id):
     if request.method == "POST" and request.is_ajax():
         analyst = request.user.username
         if is_admin(analyst):
-            date = datetime.datetime.strptime(request.POST['key'],
+            key = request.POST['key'].split(',')
+            date = datetime.datetime.strptime(key[0],
                                               settings.PY_DATETIME_FORMAT)
             date = date.replace(microsecond=date.microsecond/1000*1000)
-            result = action_remove(obj_type, obj_id, date, analyst)
+            result = action_remove(obj_type, obj_id, date, key[1], analyst)
             return HttpResponse(json.dumps(result),
                                 content_type="application/json")
         else:

--- a/extras/www/static/js/data.js
+++ b/extras/www/static/js/data.js
@@ -33,8 +33,8 @@ $('#object_data').editable(function(value, settings) {
     },
     {
         type: 'textarea',
-        height: "50px",
-        width: "400px",
+        height: "200px",
+        width: "800px",
         tooltip: "",
         cancel: "Cancel",
         submit: "Ok",

--- a/extras/www/static/js/dialogs.js
+++ b/extras/www/static/js/dialogs.js
@@ -691,6 +691,11 @@ function addEditSubmit(e) {
     }
     var form = dialog.find("form");
 
+    var sel = form.find('#id_action_type');
+    if (typeof sel !== "undefined") {
+        sel.attr('disabled', false);
+    }
+
     var type = form.attr('item-type');
     if (!type)
     log("Form (" + form.attr('id') + ") should have a defined item-type");
@@ -917,6 +922,7 @@ function update_dialog(e) {
                         sel.append($('<option></option>').val(y).html(y));
                     });
                     sel.find('option[value="' + sel_val + '"]').attr('selected', true);
+                    sel.attr('disabled', true);
                 }
             });
         }

--- a/extras/www/static/js/key_nav.js
+++ b/extras/www/static/js/key_nav.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
                 $( "#new-domain" ).click();
             } else if (e.keyCode==80) {
                 $( "#new-pcap" ).click();
-           } else if (e.keyCode==83 && e.shiftKey) {
+            } else if (e.keyCode==83 && e.shiftKey) {
                 $( "#new-signature" ).click();
             } else if (e.keyCode==83) {
                 $( "#new-sample" ).click();


### PR DESCRIPTION
There were situations with preferred actions where each action added
would get the exact same datetime of when it was added. This caused
issues with editing and deleting since we keyed off of the datetime
only. This change modifies a couple things.

First, we now get a new datetime for each preferred action added.
Second, since that doesn't 100% guarantee uniqueness, we now require the
action type to be passed in as well when deleting. Third, we no longer
allow for editing the action type and it is now used as well as the
datetime to find the action you are editing.

Ran a collectstatic which picked up a couple other changes that were
lingering and never collected before.