### PR TITLE
Fix auth for running scripts

### DIFF
--- a/crits/settings.py
+++ b/crits/settings.py
@@ -503,7 +503,7 @@ else:
     SESSION_SERIALIZER = 'django_mongoengine.sessions.BSONSerializer'
 
     AUTHENTICATION_BACKENDS = (
-        'django_mongoengine.mongo_auth.backends.MongoEngineBackend',
+        #'django_mongoengine.mongo_auth.backends.MongoEngineBackend',
         'crits.core.user.CRITsAuthBackend',
     )
 


### PR DESCRIPTION
I just noticed that we don't need that auth backend, and it broke the auth for scripts ran through "manage.py runscript"