### PR TITLE
Only Write Target email_count to DB if Value Changes

### DIFF
--- a/crits/stats/handlers.py
+++ b/crits/stats/handlers.py
@@ -255,8 +255,9 @@ def target_user_stats():
                 targs[0].email_address = result.key.strip().lower()
 
             for targ in targs:
-                targ.email_count = result.value['count']
-                targ.save()
+                if targ.email_count != result.value['count']:
+                    targ.email_count = result.value['count']
+                    targ.save()
         except:
             pass
     mapcode = """
@@ -274,8 +275,9 @@ def target_user_stats():
             if not div:
                 div = Division()
                 div.division = result.key
-            div.email_count = result.value['count']
-            div.save()
+            if div.email_count != result.value['count']:
+                div.email_count = result.value['count']
+                div.save()
     except:
         raise
 


### PR DESCRIPTION
Every time the mapreduce job runs, regardless of whether or not the email_count has changed, CRITs re-writes to the DB each Target where the count is not zero. While somewhat trivial, unnecessary DB write operations should probably be avoided.  Additionally, the write operation updates the "modified" timestamp, which could be misleading.

Same thing for division email_count.