### PR TITLE
Remove unnecessary cgi_escape()

### DIFF
--- a/crits/raw_data/templates/raw_data_details.html
+++ b/crits/raw_data/templates/raw_data_details.html
@@ -186,7 +186,7 @@
         <span>Data<span>
         </h3>
         <div>
-            <pre>{{ raw_data.data|cgi_escape }}</pre>
+            <pre>{{ raw_data.data }}</pre>
         </div>
     </div>
 </div>


### PR DESCRIPTION
cgi_escape was double escaping the content, there was a difference between raw_data content in Details tab vs RawData tab.