### PR TITLE
Remove duplicate call to generate_filetypes()

### DIFF
--- a/crits/core/management/commands/mapreduces.py
+++ b/crits/core/management/commands/mapreduces.py
@@ -16,7 +16,6 @@ class Command(BaseCommand):
         stats.generate_yara_hits()
         stats.generate_sources()
         stats.generate_filetypes()
-        stats.generate_filetypes()
         stats.generate_campaign_stats()
         stats.generate_counts()
         stats.target_user_stats()


### PR DESCRIPTION
Is there a reason that this function is called twice in a row?