### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest
+
+MAINTAINER crits
+
+RUN apt-get -qq update
+# git command
+RUN apt-get install -y git
+# pip command
+RUN apt-get install -y python-pip
+# lsb_release command
+RUN apt-get install -y lsb-release 
+# sudo command
+RUN apt-get install -y sudo
+# add-apt-repository command
+RUN apt-get install -y software-properties-common
+
+RUN git clone --depth 1 https://github.com/crits/crits.git 
+
+WORKDIR crits
+RUN TERM=xterm sh script/bootstrap < docker_inputs
+
+EXPOSE 8080
+
+CMD sh contrib/mongo/mongod_start.sh && python manage.py runserver 0.0.0.0:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y sudo
 RUN apt-get install -y software-properties-common
 
 # Clone the repo
-RUN git clone --depth 1 https://github.com/moshekaplan/crits.git 
+RUN git clone --depth 1 https://github.com/crits/crits.git 
 
 WORKDIR crits
 # Install the dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN git clone --depth 1 https://github.com/moshekaplan/crits.git
 WORKDIR crits
 # Install the dependencies
 RUN TERM=xterm sh ./script/bootstrap < docker_inputs
+
 # Create a new admin. Username: "admin" , Password: "pass1PASS123!"
-RUN python manage.py users -u admin -p "pass1PASS123!" -s -i -a -A -e admin@crits.crits -f "first" -l "last" -o "no-org"
+RUN sh contrib/mongo/mongod_start.sh && python manage.py users -u admin -p "pass1PASS123!" -s -i -a -A -e admin@crits.crits -f "first" -l "last" -o "no-org"
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN apt-get install -y sudo
 # add-apt-repository command
 RUN apt-get install -y software-properties-common
 
-RUN git clone --depth 1 https://github.com/crits/crits.git 
+# Clone the repo
+RUN git clone --depth 1 https://github.com/moshekaplan/crits.git 
 
 WORKDIR crits
-RUN TERM=xterm sh script/bootstrap < docker_inputs
+# Install the dependencies
+RUN TERM=xterm sh ./script/bootstrap < docker_inputs
+# Create a new admin. Username: "admin" , Password: "pass1PASS123!"
+RUN python manage.py users -u admin -p "pass1PASS123!" -s -i -a -A -e admin@crits.crits -f "first" -l "last" -o "no-org"
 
 EXPOSE 8080
 

--- a/crits/core/management/commands/users.py
+++ b/crits/core/management/commands/users.py
@@ -71,6 +71,11 @@ class Command(BaseCommand):
                     dest='organization',
                     default='',
                     help='Assign user to an organization/source.'),
+        make_option('--password',
+                    '-p',
+                    dest='password',
+                    default='',
+                    help='Specify a password for the account.'),
         make_option('--reset',
                     '-r',
                     dest='reset',
@@ -120,7 +125,7 @@ class Command(BaseCommand):
         lastname = options.get('lastname')
         sendemail = options.get('sendemail')
         organization = options.get('organization')
-        password = self.temp_password()
+        password = options.get('password')
         reset = options.get('reset')
         setactive = options.get('setactive')
         username = options.get('username')
@@ -129,6 +134,10 @@ class Command(BaseCommand):
         if not username:
             raise CommandError("Must provide a username.")
         user = CRITsUser.objects(username=username).first()
+
+        # Generate a password if one is not provided
+        if not password:
+            password = self.temp_password()
 
         # If we've found a user with that username and we aren't trying to add a
         # new user...

--- a/docker_inputs
+++ b/docker_inputs
@@ -5,4 +5,4 @@ first
 last
 admin@crits.crits
 crits_org
-s
+q

--- a/docker_inputs
+++ b/docker_inputs
@@ -1,9 +1,3 @@
 y
-a
-admin
-first
-last
-admin@crits.crits
-crits_org
 q
 

--- a/docker_inputs
+++ b/docker_inputs
@@ -1,0 +1,8 @@
+y
+a
+admin
+first
+last
+admin@crits.crits
+crits_org
+s

--- a/docker_inputs
+++ b/docker_inputs
@@ -6,3 +6,4 @@ last
 admin@crits.crits
 crits_org
 q
+

--- a/documentation/help_docker
+++ b/documentation/help_docker
@@ -1,0 +1,5 @@
+# Build the docker image:
+docker build -t crits/crits .
+
+# Run the docker image, exposing port 8080 for crits
+docker run --publish=8080:8080 crits:latest

--- a/documentation/help_docker
+++ b/documentation/help_docker
@@ -2,4 +2,4 @@
 docker build -t crits/crits .
 
 # Run the docker image, exposing port 8080 for crits
-docker run --publish=8080:8080 crits:latest
+docker run --publish=8080:8080 crits/crits:latest


### PR DESCRIPTION
Created a Dockerfile with crits and its dependencies.

All the required components (crits, MongoDB, ...) are included in a single Docker container. No additional configuration is needed. The docker-based crits instance can be started with the following command:

`docker run --publish=8080:8080 crits/crits:latest`

The instance can then be accessed on `localhost:8080`

The default username is: `admin`
The default password is `pass1PASS123!`
