### PR TITLE
exception on Target upload from no 'source' field

### DIFF
--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -466,8 +466,10 @@ def finish_task(object_type, object_id, analysis_id, status, analyst):
 
     # Validate user can add service results to this TLO.
     klass = class_from_type(object_type)
-    sources = user_sources(analyst)
-    obj = klass.objects(id=object_id, source__name__in=sources).first()
+    params = {'id': object_id}
+    if 'source' in klass._meta['schema_doc']:
+        params['source__name__in'] = user_sources(analyst)
+    obj = klass.objects(**params).first()
     if not obj:
         results['message'] = "Could not find object to add results to."
         return results

--- a/crits/services/handlers.py
+++ b/crits/services/handlers.py
@@ -467,7 +467,7 @@ def finish_task(object_type, object_id, analysis_id, status, analyst):
     # Validate user can add service results to this TLO.
     klass = class_from_type(object_type)
     params = {'id': object_id}
-    if 'source' in klass._meta['schema_doc']:
+    if hasattr(klass, 'source'):
         params['source__name__in'] = user_sources(analyst)
     obj = klass.objects(**params).first()
     if not obj:


### PR DESCRIPTION
When uploading a new Target TLO, I encounter the following exception in the `finish_task` function:

```
HTTP/1.1" 200 799
Process Process-4:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/crits/crits/services/core.py", line 472, in execute
    self.current_task.username)
  File "/opt/crits/crits/services/handlers.py", line 470, in finish_task
    obj = klass.objects(id=object_id, source__name__in=sources).first()
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 264, in first
    result = queryset[0]
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 161, in __getitem__
    return queryset._document._from_son(queryset._cursor[key],
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 1481, in _cursor
    self._cursor_obj = self._collection.find(self._query,
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 1515, in _query
    self._mongo_query = self._query_obj.to_query(self._document)
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 90, in to_query
    query = query.accept(QueryCompilerVisitor(document))
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 155, in accept
    return visitor.visit_query(self)
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 78, in visit_query
    return transform.query(self.document, **query.query)
  File "/usr/lib/python2.7/site-packages/mongoengine/queryset/transform.py", line 61, in query
    raise InvalidQueryError(e)
InvalidQueryError: Cannot resolve field "source"
```

I believe the reason for this is because the Target TLO does not contain a `source` field. The code in this pull request changes the `klass.objects` call to pass on a params dict, which only contains the `id` key unless the TLO's `klass. _meta['schema_doc']` dict contains the key `source`, which appears to be present in all other TLOs. Since Targets dont have a `source` I dont _think_ this would effect the search results.