### PR TITLE
This change makes CRITs work on Mongoengine 0.12

### DIFF
--- a/crits/services/analysis_result.py
+++ b/crits/services/analysis_result.py
@@ -88,7 +88,7 @@ class AnalysisResult(CritsDocument, CritsSchemaDocument, CritsDocumentFormatter,
     log = ListField(EmbeddedDocumentField(EmbeddedAnalysisResultLog))
     object_type = StringField(required=True)
     object_id = StringField(required=True)
-    results = ListField(DynamicField(dict))
+    results = ListField(DynamicField())
     service_name = StringField()
     source = StringField()
     start_date = StringField()

--- a/crits/services/analysis_result.py
+++ b/crits/services/analysis_result.py
@@ -88,7 +88,7 @@ class AnalysisResult(CritsDocument, CritsSchemaDocument, CritsDocumentFormatter,
     log = ListField(EmbeddedDocumentField(EmbeddedAnalysisResultLog))
     object_type = StringField(required=True)
     object_id = StringField(required=True)
-    results = ListField(DynamicField(DictField))
+    results = ListField(DynamicField(dict))
     service_name = StringField()
     source = StringField()
     start_date = StringField()


### PR DESCRIPTION
This thing broke after https://github.com/MongoEngine/mongoengine/pull/1497 was merged.
I'm not really sure if this is the right fix, it seems that mongoengine/fields.py#L625 added a check for 'dict'.