### PR TITLE
Fix sort direction of dashboard tables

### DIFF
--- a/crits/dashboards/templates/dashboard.html
+++ b/crits/dashboards/templates/dashboard.html
@@ -325,7 +325,7 @@
 	            var editUrl = '{% url "crits.dashboards.views.edit_save_search" table.id %}';
 	            {% if table.sortBy %}
 	                var sortField = '{{table.sortBy.field}}';
-	                var sortDirection = '{{table.sortBy.field}}';
+	                var sortDirection = '{{table.sortBy.direction}}';
 	            {% endif %}
 	            {% if table.isHereByDefault %}
 	                isDefault = true;


### PR DESCRIPTION
A typo, or copy-paste error, was preventing proper sorting of custom dashboard tables.  This change enables the sort direction value to be retrieved by the database.