### PR TITLE
Remove "Generic" default Sample upload Source Method

### DIFF
--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -651,7 +651,7 @@ def unzip_file(filename, user=None, password=None, data=None, source=None,
             shutil.rmtree(extractdir)
     return samples
 
-def handle_file(filename, data, source, method='Generic', reference='',
+def handle_file(filename, data, source, method='', reference='',
                 related_md5=None, related_id=None, related_type=None,
                 relationship_type=None, backdoor=None, user='', campaign=None,
                 confidence='low', md5_digest=None, sha1_digest=None,


### PR DESCRIPTION
Having the default argument for the `source` parameter of Sample's `handle_file` function set to "Generic" has led to some problems.  If the `source` argument is an EmbeddedSource instance, then the method and reference are part of that instance and likely will not be included as separate arguments. However, the code functions in such a way that a provided method or reference argument will override the values in the EmbeddedSource instance, which leads to the method being overwritten by the default value "Generic".

I'm not sure why the default was "Generic" anyway.