### PR TITLE
Record User for TLO Creation/Modification & Status Modification

### DIFF
--- a/crits/actors/templates/actor_detail.html
+++ b/crits/actors/templates/actor_detail.html
@@ -64,7 +64,7 @@
                     </tr>
                     <tr>
                         <td class="key">Created</td>
-                        <td>{{actor.created}}</td>
+                        <td>{{actor.created}}{% if actor.created_by %} by {{ actor.created_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Modified</td>

--- a/crits/actors/templates/actor_detail.html
+++ b/crits/actors/templates/actor_detail.html
@@ -68,7 +68,7 @@
                     </tr>
                     <tr>
                         <td class="key">Modified</td>
-                        <td>{{actor.modified}}</td>
+                        <td>{{actor.modified}}{% if actor.modified_by %} by {{ actor.modified_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Status

--- a/crits/actors/templates/actor_detail.html
+++ b/crits/actors/templates/actor_detail.html
@@ -75,7 +75,7 @@
                             <span style="float: right;" class="object_status_response"></span>
                         </td>
                         <td>
-                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{actor.status}}</span>
+                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{actor.status}}</span>{% if actor.status_modified %} - <span id="status_meta">Last set by {{ actor.status_modified.analyst }} at {{ actor.status_modified.date }}{% endif %}</span>
                         </td>
                     </tr>
                     {% include "actor_tags_widget.html" %}

--- a/crits/backdoors/templates/backdoor_detail.html
+++ b/crits/backdoors/templates/backdoor_detail.html
@@ -70,7 +70,7 @@
                     </tr>
                     <tr>
                         <td class="key">Created</td>
-                        <td>{{backdoor.created}}</td>
+                        <td>{{backdoor.created}}{% if backdoor.created_by %} by {{ backdoor.created_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Modified</td>

--- a/crits/backdoors/templates/backdoor_detail.html
+++ b/crits/backdoors/templates/backdoor_detail.html
@@ -81,7 +81,7 @@
                             <span style="float: right;" class="object_status_response"></span>
                         </td>
                         <td>
-                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{backdoor.status}}</span>
+                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{backdoor.status}}</span>{% if backdoor.status_modified %} - <span id="status_meta">Last set by {{ backdoor.status_modified.analyst }} at {{ backdoor.status_modified.date }}{% endif %}</span>
                         </td>
                     </tr>
                     {% with sectors=backdoor.sectors %}

--- a/crits/backdoors/templates/backdoor_detail.html
+++ b/crits/backdoors/templates/backdoor_detail.html
@@ -74,7 +74,7 @@
                     </tr>
                     <tr>
                         <td class="key">Modified</td>
-                        <td>{{backdoor.modified}}</td>
+                        <td>{{backdoor.modified}}{% if backdoor.modified_by %} by {{ backdoor.modified_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Status

--- a/crits/campaigns/templates/campaign_detail.html
+++ b/crits/campaigns/templates/campaign_detail.html
@@ -68,7 +68,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{campaign_detail.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{campaign_detail.status}}</span>{% if campaign_detail.status_modified %} - <span id="status_meta">Last set by {{ campaign_detail.status_modified.analyst }} at {{ campaign_detail.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=campaign_detail.sectors %}

--- a/crits/certificates/templates/certificate_details.html
+++ b/crits/certificates/templates/certificate_details.html
@@ -52,7 +52,7 @@
             </tr>
             <tr>
             <td class='key'>Created</td>
-            <td>{{ cert.created }}</td>
+            <td>{{ cert.created }}{% if cert.created_by %} by {{ cert.created_by }}{% endif %}</td>
             </tr>
             <tr>
             <td class='key'>Size</td>

--- a/crits/certificates/templates/certificate_details.html
+++ b/crits/certificates/templates/certificate_details.html
@@ -72,7 +72,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{cert.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{cert.status}}</span>{% if cert.status_modified %} - <span id="status_meta">Last set by {{ cert.status_modified.analyst }} at {{ cert.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=cert.sectors %}

--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -286,12 +286,14 @@ class CritsStatusDocument(BaseDocument):
 
 class CritsBaseDocument(BaseDocument):
     """
-    Inherit to add a created and modified date to a top-level object.
+    Inherit to add created and modified dates, and the user who last modified,
+    to a top-level object.
     """
 
     created = CritsDateTimeField(default=datetime.datetime.now)
     # modified will be overwritten on save
     modified = CritsDateTimeField()
+    modified_by = StringField()
 
 
 class CritsSchemaDocument(BaseDocument):
@@ -371,6 +373,7 @@ class CritsDocument(BaseDocument):
         #TODO: convert this to using UTC
         if hasattr(self, 'modified'):
             self.modified = datetime.datetime.now()
+            self.modified_by = username
         do_audit = False
         if self.id:
             audit_entry(self, username, "save")

--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -291,6 +291,8 @@ class CritsBaseDocument(BaseDocument):
     """
 
     created = CritsDateTimeField(default=datetime.datetime.now)
+    created_by = StringField()
+
     # modified will be overwritten on save
     modified = CritsDateTimeField()
     modified_by = StringField()
@@ -378,6 +380,7 @@ class CritsDocument(BaseDocument):
         if self.id:
             audit_entry(self, username, "save")
         else:
+            self.created_by = username
             do_audit = True
         super(self.__class__, self).save(force_insert=force_insert,
                                          validate=validate,

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -379,7 +379,7 @@ def status_update(type_, id_, value="In Progress", user=None, **kwargs):
     if not obj:
         return {'success': False, 'message': 'Could not find object.'}
     try:
-        obj.set_status(value)
+        obj.set_status(value, user)
         # Check to see if the set_status was successful or not.
         if obj.status != value:
             return {'success': False, 'message': 'Invalid status: %s.' % value }

--- a/crits/core/static/js/core.js
+++ b/crits/core/static/js/core.js
@@ -1409,6 +1409,7 @@ $(document).ready(function() {
     $('#object_status.edit').editable(function(value, settings) {
         revert = this.revert;
         var her = $(this).closest('tr').find('.object_status_response');
+        var sm = $(this).closest('tr').find('#status_meta');
         return function(value, settings, elem) {
             $.ajax({
                 type:"POST",
@@ -1427,6 +1428,7 @@ $(document).ready(function() {
                         her.addClass('ui-icon');
                         her.addClass('ui-icon-circle-check');
                         her.attr('title', "Success!");
+                        sm.html('Last set by ' + username + ' a moment ago');
                     }
                 }
             });

--- a/crits/domains/templates/domain_detail.html
+++ b/crits/domains/templates/domain_detail.html
@@ -52,7 +52,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{domain.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{domain.status}}</span>{% if domain.status_modified %} - <span id="status_meta">Last set by {{ domain.status_modified.analyst }} at {{ domain.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=domain.sectors %}

--- a/crits/domains/templates/domain_detail.html
+++ b/crits/domains/templates/domain_detail.html
@@ -36,7 +36,7 @@
             </tr>
             <tr>
                 <td class="key">Created</td>
-                <td>{{domain.created}}</td>
+                <td>{{domain.created}}{% if domain.created_by %} by {{ domain.created_by }}{% endif %}</td>
             </tr>
             <tr>
                 {% with description=domain.description %}

--- a/crits/emails/templates/email_detail.html
+++ b/crits/emails/templates/email_detail.html
@@ -105,7 +105,7 @@
                 <span style="float: right;" class="object_status_response"></span>
             </td>
             <td>
-                <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{email.status}}</span>
+                <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{email.status}}</span>{% if email.status_modified %} - <span id="status_meta">Last set by {{ email.status_modified.analyst }} at {{ email.status_modified.date }}{% endif %}</span>
             </td>
         </tr>
         {% with sectors=email.sectors %}

--- a/crits/events/templates/event_detail.html
+++ b/crits/events/templates/event_detail.html
@@ -73,7 +73,7 @@
                             <span style="float: right;" class="object_status_response"></span>
                         </td>
                         <td>
-                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{event.status}}</span>
+                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{event.status}}</span>{% if event.status_modified %} - <span id="status_meta">Last set by {{ event.status_modified.analyst }} at {{ event.status_modified.date }}{% endif %}</span>
                         </td>
                     </tr>
                     {% with sectors=event.sectors %}

--- a/crits/events/templates/event_detail.html
+++ b/crits/events/templates/event_detail.html
@@ -61,7 +61,7 @@
                     </tr>
                     <tr>
                         <td class='key'>Created</td>
-                        <td>{{ event.created }}</td>
+                        <td>{{ event.created }}{% if event.created_by %} by {{ event.created_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         {% with description=event.description %}

--- a/crits/exploits/templates/exploit_detail.html
+++ b/crits/exploits/templates/exploit_detail.html
@@ -58,7 +58,7 @@
                     </tr>
                     <tr>
                         <td class="key">Created</td>
-                        <td>{{exploit.created}}</td>
+                        <td>{{exploit.created}}{% if exploit.created_by %} by {{ exploit.created_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Modified</td>

--- a/crits/exploits/templates/exploit_detail.html
+++ b/crits/exploits/templates/exploit_detail.html
@@ -62,7 +62,7 @@
                     </tr>
                     <tr>
                         <td class="key">Modified</td>
-                        <td>{{exploit.modified}}</td>
+                        <td>{{exploit.modified}}{% if exploit.modified_by %} by {{ exploit.modified_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         <td class="key">Status

--- a/crits/exploits/templates/exploit_detail.html
+++ b/crits/exploits/templates/exploit_detail.html
@@ -69,7 +69,7 @@
                             <span style="float: right;" class="object_status_response"></span>
                         </td>
                         <td>
-                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{exploit.status}}</span>
+                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{exploit.status}}</span>{% if exploit.status_modified %} - <span id="status_meta">Last set by {{ exploit.status_modified.analyst }} at {{ exploit.status_modified.date }}{% endif %}</span>
                         </td>
                     </tr>
                     {% with sectors=exploit.sectors %}

--- a/crits/indicators/templates/indicator_detail.html
+++ b/crits/indicators/templates/indicator_detail.html
@@ -134,7 +134,7 @@
             Last Modified
         </td>
         <td>
-            {{ indicator.modified }}
+            {{ indicator.modified }}{% if indicator.modified_by %} by {{ indicator.modified_by }}{% endif %}
         </td>
         </tr>
         <tr>

--- a/crits/indicators/templates/indicator_detail.html
+++ b/crits/indicators/templates/indicator_detail.html
@@ -162,7 +162,7 @@
             <span style="float: right;" class="object_status_response"></span>
         </td>
         <td>
-            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{indicator.status}}</span>
+            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{indicator.status}}</span>{% if indicator.status_modified %} - <span id="status_meta">Last set by {{ indicator.status_modified.analyst }} at {{ indicator.status_modified.date }}{% endif %}</span>
         </td>
         </tr>
         {% with sectors=indicator.sectors %}

--- a/crits/indicators/templates/indicator_detail.html
+++ b/crits/indicators/templates/indicator_detail.html
@@ -126,7 +126,7 @@
             Creation Date
         </td>
         <td>
-            {{ indicator.created }}
+            {{ indicator.created }}{% if indicator.created_by %} by {{ indicator.created_by }}{% endif %}
         </td>
         </tr>
         <tr>

--- a/crits/ips/templates/ip_detail.html
+++ b/crits/ips/templates/ip_detail.html
@@ -51,7 +51,7 @@
                             <span style="float: right;" class="object_status_response"></span>
                         </td>
                         <td>
-                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{ip.status}}</span>
+                            <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{ip.status}}</span>{% if ip.status_modified %} - <span id="status_meta">Last set by {{ ip.status_modified.analyst }} at {{ ip.status_modified.date }}{% endif %}</span>
                         </td>
                     </tr>
                     {% with sectors=ip.sectors %}

--- a/crits/ips/templates/ip_detail.html
+++ b/crits/ips/templates/ip_detail.html
@@ -31,7 +31,7 @@
                     </tr>
                     <tr>
                         <td class="key">Created</td>
-                        <td>{{ip.created}}</td>
+                        <td>{{ip.created}}{% if ip.created_by %} by {{ ip.created_by }}{% endif %}</td>
                     </tr>
                     <tr>
                         {% with description=ip.description %}

--- a/crits/pcaps/templates/pcap_detail.html
+++ b/crits/pcaps/templates/pcap_detail.html
@@ -67,7 +67,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{pcap.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{pcap.status}}</span>{% if pcap.status_modified %} - <span id="status_meta">Last set by {{ pcap.status_modified.analyst }} at {{ pcap.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=pcap.sectors %}

--- a/crits/pcaps/templates/pcap_detail.html
+++ b/crits/pcaps/templates/pcap_detail.html
@@ -48,7 +48,7 @@
             </tr>
             <tr>
             <td class='key'>Created</td>
-            <td>{{ pcap.created }}</td>
+            <td>{{ pcap.created }}{% if pcap.created_by %} by {{ pcap.created_by }}{% endif %}</td>
             </tr>
             <tr>
             <td class='key'>Length</td>

--- a/crits/raw_data/templates/raw_data_details.html
+++ b/crits/raw_data/templates/raw_data_details.html
@@ -58,7 +58,7 @@
             </tr>
             <tr>
             <td class='key'>Created</td>
-            <td>{{ raw_data.created }}</td>
+            <td>{{ raw_data.created }}{% if raw_data.created_by %} by {{ raw_data.created_by }}{% endif %}</td>
             </tr>
             <tr>
             <td class='key'>Tool</td>

--- a/crits/raw_data/templates/raw_data_details.html
+++ b/crits/raw_data/templates/raw_data_details.html
@@ -114,7 +114,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{raw_data.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{raw_data.status}}</span>{% if raw_data.status_modified %} - <span id="status_meta">Last set by {{ raw_data.status_modified.analyst }} at {{ raw_data.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=raw_data.sectors %}

--- a/crits/samples/templates/samples_detail.html
+++ b/crits/samples/templates/samples_detail.html
@@ -119,7 +119,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{sample.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{sample.status}}</span>{% if sample.status_modified %} - <span id="status_meta">Last set by {{ sample.status_modified.analyst }} at {{ sample.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=sample.sectors %}

--- a/crits/signatures/templates/signature_detail.html
+++ b/crits/signatures/templates/signature_detail.html
@@ -53,7 +53,7 @@
             </tr>
             <tr>
             <td class='key'>Created</td>
-            <td>{{ signature.created }}</td>
+            <td>{{ signature.created }}{% if signature.created_by %} by {{ signature.created_by }}{% endif %}</td>
             </tr>
             <tr>
                 <td class='key'>Data Type</td>

--- a/crits/signatures/templates/signature_detail.html
+++ b/crits/signatures/templates/signature_detail.html
@@ -102,7 +102,7 @@
                     <span style="float: right;" class="object_status_response"></span>
                 </td>
                 <td>
-                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{signature.status}}</span>
+                    <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{signature.status}}</span>{% if signature.status_modified %} - <span id="status_meta">Last set by {{ signature.status_modified.analyst }} at {{ signature.status_modified.date }}{% endif %}</span>
                 </td>
             </tr>
             {% with sectors=signature.sectors %}

--- a/crits/targets/templates/target.html
+++ b/crits/targets/templates/target.html
@@ -77,7 +77,7 @@
                 <span style="float: right;" class="object_status_response"></span>
             </td>
             <td>
-                <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{target_detail.status}}</span>
+                <span class="edit" id="object_status" action="{% url 'crits.core.views.update_status' subscription.type subscription.id %}">{{target_detail.status}}</span>{% if target_detail.status_modified %} - <span id="status_meta">Last set by {{ target_detail.status_modified.analyst }} at {{ target_detail.status_modified.date }}{% endif %}</span>
             </td>
         </tr>
         {% with sectors=target_detail.sectors %}

--- a/extras/www/static/js/core.js
+++ b/extras/www/static/js/core.js
@@ -1409,6 +1409,7 @@ $(document).ready(function() {
     $('#object_status.edit').editable(function(value, settings) {
         revert = this.revert;
         var her = $(this).closest('tr').find('.object_status_response');
+        var sm = $(this).closest('tr').find('#status_meta');
         return function(value, settings, elem) {
             $.ajax({
                 type:"POST",
@@ -1427,6 +1428,7 @@ $(document).ready(function() {
                         her.addClass('ui-icon');
                         her.addClass('ui-icon-circle-check');
                         her.attr('title', "Success!");
+                        sm.html('Last set by ' + username + ' a moment ago');
                     }
                 }
             });


### PR DESCRIPTION
Sometimes it is not always clear which user created a particular TLO and who last modified a TLO.
Additionally, from a workflow perspective, it is important to know who last modified a TLO's status field.
This change sets a few new values in the database to record this information for all TLOs.  Because these are new fields, no migration is necessary.

While implementing this, I realized that the display of creation/modification timestamps on TLO detail pages is very inconsistent. Some show both, while others show just one or neither.  This PR does not change which TLOs display those values, but I think it might be valuable to discuss making this consistent across all TLOs.

I'm open to feedback. Let me know if you notice that I missed something!