### PR TITLE
Validate check_source_tlp() input before trying to use it.

### DIFF
--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -885,6 +885,9 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         """
         """
 
+        if not object:
+            return False
+
         user_source_names = self.get_sources_list()
         user_source_objects = self._meta['cached_acl'].sources
 

--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -193,7 +193,7 @@ def get_indicator_details(indicator_id, user):
     indicator = Indicator.objects(id=indicator_id,
                                   source__name__in=users_sources).first()
 
-    if not user.check_source_tlp(indicator):
+    if not indicator or not user.check_source_tlp(indicator):
         indicator = None
 
     if not indicator:


### PR DESCRIPTION
Check for valid objects before using it.