### PR TITLE
Fix CSV export of actions & simple list fields

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -144,7 +144,7 @@ class CritsQuerySet(QS):
         for key in filter_keys:
             if key in fields:
                 fields.remove(key)
-        csvout = ",".join(fields) + "\n"
+        csvout = str(",".join(fields) + "\n")
         csvout += "".join(obj.to_csv(fields) for obj in self)
         return csvout
 
@@ -530,7 +530,9 @@ class CritsDocument(BaseDocument):
         for field in fields:
             if field in self._data:
                 data = ""
-                if field == "aliases" and self._has_method("get_aliases"):
+                if field == "actions" and self._has_method("get_action_types"):
+                    data = ";".join(self.get_action_types())
+                elif field == "aliases" and self._has_method("get_aliases"):
                     data = ";".join(self.get_aliases())
                 elif field == "campaign" and self._has_method("get_campaign_names"):
                     data = ';'.join(self.get_campaign_names())
@@ -541,9 +543,13 @@ class CritsDocument(BaseDocument):
                 else:
                     data = self._data[field]
                     if not hasattr(data, 'encode'):
-                        # Convert non-string data types
-                        data = unicode(data)
+                        try: # convert list of strings
+                            data = ";".join(data)
+                        except: # Convert non-string data types
+                            data = unicode(data)
                 row.append(data.encode('utf-8'))
+            else:
+                row.append('')
 
         csv_wr.writerow(row)
         return csv_string.getvalue()
@@ -813,6 +819,22 @@ class CritsActionsDocument(BaseDocument):
                 ea.date = date
                 self.actions.append(ea)
                 break
+
+    def get_action_types(self, active_only=False):
+        """
+        Return a list of action types applied to the object.
+
+        :param active_only: If True, only return active Actions.
+                            If False, return all Actions.
+        :type active_only: boolean
+        :returns: bool
+        """
+
+        if active_only:
+            return [a['action_type'] for a in self._data['actions']
+                                         if a['active'] == 'on']
+        else:
+            return [a['action_type'] for a in self._data['actions']]
 
 # Embedded Documents common to most classes
 class EmbeddedSource(EmbeddedDocument, CritsDocumentFormatter):


### PR DESCRIPTION
This addresses the following:
- If the Indicator list was exported to CSV, the "actions" column would display something like `[<EmbeddedAction: EmbeddedAction object>, <EmbeddedAction: EmbeddedAction object>, <EmbeddedAction: EmbeddedAction object>]` instead of the action_types.  Similarly, the bucket_list column was not exporting cleanly.
- The code allowed for a rare case where a column header could be included for which no data was provided. This would lead to mismatched rows and encode/decode issues.