### PR TITLE
Fix regex find assumption

### DIFF
--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -1293,8 +1293,10 @@ def dict_to_email(d, save_unsupported=True):
     clean_dict(d, keys)
 
     if 'x_originating_ip' in d and d['x_originating_ip']:
-        d['x_originating_ip'] = re.findall(r'[0-9]+(?:\.[0-9]+){3}',
-                                           d['x_originating_ip'])[0]
+        orig_ipv4 = re.findall(r'[0-9]+(?:\.[0-9]+){3}',
+                               d['x_originating_ip'])
+        if orig_ipv4:
+            d['x_originating_ip'] = orig_ipv4[0]
 
     if 'date' in d and d['date']:
         if isinstance(d['date'], datetime.datetime):


### PR DESCRIPTION
When x_originating_ip is set to an IPv6 value, the previous findall function returns 0 matches, causing an error. This fixes that and either sets x_originating_ip to the IPv6 value or the first IPv4 matched by the regex.