### PR TITLE
Fix and improve API queries for c-_id on TLOs

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -449,7 +449,7 @@ class CRITsAPIResource(MongoEngineResource):
                     querydict['_id'] = ObjectId(v)
                 except:
                     pass
-            if k.startswith("c-"):
+            elif k.startswith("c-"):
                 field = k[2:]
                 # Attempt to discover query operators. We use django-style operators
                 # (same as MongoEngine). These also override regex.

--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -444,9 +444,21 @@ class CRITsAPIResource(MongoEngineResource):
             except:
                 # If can't be converted to an int use the string.
                 v_int = v
-            if k == "c-_id":
+            if k == "c-_id" or k.find("c-_id__") == 0:
                 try:
-                    querydict['_id'] = ObjectId(v)
+                    field = "_id"
+
+                    # Attempt to extract an "in" or "nin" operator
+                    try:
+                        op_index = k.index("__")
+                        op = "$%s" % k[op_index+2:]
+                    except ValueError:
+                        op_index = None
+
+                    if op_index == None:
+                        querydict[field] = ObjectId(v)
+                    elif op in ['$in', '$nin']:
+                        querydict[field] = {op: [ObjectId(x) for x in v.split(',')]}
                 except:
                     pass
             elif k.startswith("c-"):


### PR DESCRIPTION
One of our team realized that c-_id queries in the API were broken (a small if/elif swap bug). When digging deeper, we decided it would be nice to implement the __in and __nin API operator extensions here, as the tastypie /set/ endpoint is painfully inefficient for fetching a specific list of indicators by id.

So - fixed the ?c-_id bug, and then added support for c-_id__in and c-_id__nin to the API.