### PR TITLE
Fix an issue with lingering ACL overwrites.

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -228,6 +228,16 @@ class CritsDocumentFormatter(object):
 
         return self.to_json()
 
+    def get(self, attr=None, ret=None):
+        """
+         Simulate a `.get()` from a dict.
+        """
+
+        if attr is not None:
+            return getattr(self, attr)
+
+        return ret
+
     def merge(self, arg_dict=None, overwrite=False, **kwargs):
         """
         Merge a dictionary into a top-level object class.

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -4468,7 +4468,7 @@ def users_need_acl_updating(rid=None, rname=None):
     if rname is None:
         return
 
-    CRITsUser.objects(roles=rname).update(set__acl_needs_update=True)
+    CRITsUser.objects(roles=rname).update(set__acl_needs_update=True, multi=True)
     return
 
 def add_role_source(rid, name, analyst):

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1395,6 +1395,7 @@ def modify_source_access(analyst, data):
                     'message': 'Password does not meet complexity policy: %s' % pc}
     if data['subscriptions'] == '':
         user.subscriptions = EmbeddedSubscriptions()
+    user.acl_needs_update = True
     try:
         user.save(username=analyst)
         return {'success': True}
@@ -3639,6 +3640,7 @@ def login_user(username, password, next_url=None, user_agent=None,
             user.login_attempts.append(e)
             user.save()
         if user.is_active:
+            user.get_access_list(update=True)
             user.invalid_login_attempts = 0
             user.password_reset.reset_code = ""
             user.save()
@@ -4450,6 +4452,25 @@ def edit_role_description(rid, description, analyst):
                  name__ne=settings.ADMIN_ROLE).update_one(set__description=description)
     return {'success': True}
 
+def users_need_acl_updating(rid=None, rname=None):
+    """
+    A role has been updated and users should be flagged to have their ACL
+    updated on the next ACL check.
+
+    :param rid: The ObjectID of the role in question.
+    :type rid: str
+    :param rname: The name of the role in question.
+    :type rname: str
+    """
+
+    if rid:
+        rname = Role.objects(id=rid).first().name
+    if rname is None:
+        return
+
+    CRITsUser.objects(roles=rname).update(set__acl_needs_update=True)
+    return
+
 def add_role_source(rid, name, analyst):
     """
     Add a source to a role.
@@ -4470,6 +4491,7 @@ def add_role_source(rid, name, analyst):
           'tlp_green': False}
     d = {'push__sources': ed}
     Role.objects(id=rid, name__ne=settings.ADMIN_ROLE).update_one(**d)
+    users_need_acl_updating(rid=rid)
 
     html = render_to_string('role_source_item.html',
                             {'source': ed})
@@ -4490,6 +4512,7 @@ def remove_role_source(rid, name, analyst):
 
     d = {'pull__sources': {'name': name}}
     Role.objects(id=rid, name__ne=settings.ADMIN_ROLE).update_one(**d)
+    users_need_acl_updating(rid=rid)
     return {'success': True}
 
 def set_role_value(rid, name, value, analyst):
@@ -4521,6 +4544,7 @@ def set_role_value(rid, name, value, analyst):
                      sources__name=sname).update_one(**ud)
     else:
         Role.objects(id=rid,name__ne=settings.ADMIN_ROLE).update_one(**ud)
+    users_need_acl_updating(rid=rid)
 
 def add_new_role(name, copy_from, description, analyst):
     """

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -199,7 +199,6 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
              'sparse': True,
             },
         ],
-        "cached_acl": None,
         "crits_type": 'User',
         "latest_schema_version": 3,
         "schema_doc": {
@@ -322,6 +321,8 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
     subscriptions = EmbeddedDocumentField(EmbeddedSubscriptions, default=EmbeddedSubscriptions())
     favorites = EmbeddedDocumentField(EmbeddedFavorites, default=EmbeddedFavorites())
     prefs = EmbeddedDocumentField(PreferencesField, default=PreferencesField())
+    acl_needs_update = BooleanField(default=False)
+    acl = DictField()
     totp = BooleanField(default=False)
     secret = StringField(default="")
     api_keys = ListField(EmbeddedDocumentField(EmbeddedAPIKey))
@@ -812,9 +813,9 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         l.set_option(ldap.OPT_REFERRALS, 0)
         l.set_option(ldap.OPT_TIMEOUT, 10)
         # setup auth for custom cn's
-        cn = "cn="
-        if config.ldap_usercn:
-            cn = config.ldap_usercn
+        #cn = "cn="
+        #if config.ldap_usercn:
+        #    cn = config.ldap_usercn
         # two-step ldap binding
         if len(config.ldap_bind_dn) > 0:
             try:
@@ -877,9 +878,12 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         # Made the ACL update optional as this was adding 10s to load times
         # and over 400 reads from the DB. If this breaks something, we should
         # fix it.
-        if self._meta['cached_acl'] is None:
+        if self.acl_needs_update:
             self.get_access_list(update=True)
-        return [s.name for s in self._meta['cached_acl'].sources]
+        try:
+            return [s.name for s in self.acl.get('sources')]
+        except:
+            return []
 
     def check_source_tlp(self, object):
         """
@@ -889,7 +893,7 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
             return False
 
         user_source_names = self.get_sources_list()
-        user_source_objects = self._meta['cached_acl'].sources
+        user_source_objects = self.acl.get('sources')
 
         object_sources = object.source
 
@@ -909,7 +913,7 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
     def check_source_write(self, source):
         """
         """
-        user_source_objects = self._meta['cached_acl'].sources
+        user_source_objects = self.acl.sources
 
         for usource in user_source_objects:
             if usource.name == source:
@@ -931,12 +935,12 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
 
         # If we already have this cached, return it unless we are supposed to
         # update the cache first.
-        if self._meta['cached_acl'] and not update:
-            return self._meta['cached_acl']
+        if not update:
+            return self.acl
 
-        acl=None
+        acl = {}
         roles = Role.objects(name__in=self.roles)
-        acl = roles.first()
+        acl = roles.first()._data
 
         # for each role, modify the acl object to reflect all of the attributes
         # the user should be granted access to.
@@ -984,10 +988,13 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
                     # Set the attribute if the user should get access to it.
                     if not getattr(acl, p, False):
                         setattr(acl, p, v)
-        self._meta['cached_acl'] = acl
+        acl = dict(acl)
+        self.acl = acl
+        self.acl_needs_update = False
+        self.save()
         return acl
 
-    def can_do_one_of(self, acls=[]):
+    def can_do_one_of(self, acls=None):
         """
         Given a list of possible acls, verify the user has access to do at least
         one of them.
@@ -997,18 +1004,17 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         :returns: boolean
         """
         result = False
+        if acls is None:
+            acls = []
         for acl in acls:
             if self.has_access_to(acl):
                 result = True
                 break
         return result
 
-    def has_access_to(self, attribute):
+    def has_access_to(self, attribute=None):
         """
-        Try to determine if a user has access to this feature in CRITs. If the
-        "cached_acl" field of '._meta' is None, we will cache the results of
-        '.get_access_list()' there. This will make situations where you have to
-        check several ACL values quicker.
+        Try to determine if a user has access to this feature in CRITs.
 
         Checking multiple ACL values at a time will be very common. For example:
 
@@ -1039,22 +1045,17 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         :returns: boolean
         """
 
-        if self._meta['cached_acl'] is None:
+        if self.acl_needs_update or len(self.acl) == 0:
             self.get_access_list(update=True)
 
         attrs = attribute.split('.')
-        attr = self._meta['cached_acl']
+        attr = self.acl
 
         for a in attrs:
             try:
-                attr = getattr(attr, a, False)
+                attr = attr.get(a, False)
             except:
                 return False
-        # Commenting this out. If it is included, it guarantees that every
-        # single call to this function will clear the cached ACL causing a new
-        # lookup every time. This added 3s to load time and over 150 reads to
-        # loading the dashboard alone.
-        #self._meta['cached_acl'] = None
         return attr
 
 class AuthenticationMiddleware(object):

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -913,7 +913,7 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
     def check_source_write(self, source):
         """
         """
-        user_source_objects = self.acl.sources
+        user_source_objects = self.acl.get('sources')
 
         for usource in user_source_objects:
             if usource.name == source:

--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -430,7 +430,8 @@ If you are already setup with TOTP, please enter your PIN + Key above."""
         # TOTP can still be required for Remote Users
         totp_pass = request.POST.get('totp_pass', None)
         logging_in_user = get_user_info(username)
-        if (not username or not logging_in_user.has_access_to(GeneralACL.WEB_INTERFACE) or
+        logging_in_user.get_access_list(update=True)
+        if (not username or logging_in_user is None or not logging_in_user.has_access_to(GeneralACL.WEB_INTERFACE) or
                 (not totp_pass and crits_config.totp_web == 'Required')):
             response['success'] = False
             response['message'] = 'Unknown user, bad password, or user does not have permission to log on using the web UI.'


### PR DESCRIPTION
There was an issue where the last logged in user would overwrite the ACL
for all users who already logged in and were active.

To fix this I decided to write the user's ACL to the database. This will
cause slightly more overhead in pulling the user document out of the
database, but the `acl` attribute will act as the previously-known
"cached" version of the ACL.

To accommodate the need for updating, there's also a new
`acl_needs_update` attribute for the user. This will generally be set to
False, but two conditions will set this to True:

    1) The user's account has been changed in ANY way.
    2) A role the user has been granted has been changed in ANY way.

If those conditions are met, the user's account will get flagged.
Whenever we do a `.has_access_to()` check on that user, if they are
flagged for updating, we will update their ACL first (which will save it
to the database) and then proceed with validating their access.

This seems to have fixed the issue as far as I can tell. This did come
with another issue which was how to process the user's ACL as it is
stored as a dictionary in the database. A few tweaks were made for
iterating over the ACL to find a sub-key as well as looking up their
source access.