### PR TITLE
Return error if no domain/IP component in URI or Email Address

### DIFF
--- a/crits/indicators/handlers.py
+++ b/crits/indicators/handlers.py
@@ -1391,6 +1391,8 @@ def validate_indicator_value(value, ind_type):
     # URL
     if ind_type == IndicatorTypes.URI and "://" in value.split('.')[0]:
         domain_or_ip = urlparse.urlparse(value).hostname
+        if not domain_or_ip:
+            return ("", "Failed to parse a domain or IP from the URL")
         try:
             validate_ipv46_address(domain_or_ip)
             return (value, "")
@@ -1405,6 +1407,8 @@ def validate_indicator_value(value, ind_type):
         if '@' not in value:
             return ("", "Email address must contain an '@'")
         domain_or_ip = value.split('@')[-1]
+        if not domain_or_ip:
+            return ("", "Email address must contain a domain (or IP)")
         if domain_or_ip[0] == '[' and domain_or_ip[-1] == ']':
             try:
                 validate_ipv46_address(domain_or_ip[1:-1])


### PR DESCRIPTION
Certain bad Indicator values can lead to errors during validation.  Particularly an email address like "abc@", or a URI like "http:///apple/butter/juice.aspx".