### PR TITLE
Allow newlines in Comments

### DIFF
--- a/crits/comments/comment.py
+++ b/crits/comments/comment.py
@@ -192,6 +192,7 @@ def parse_comment(comment):
                        '\'': '&apos;',
                        '>': '&gt;',
                        '<': '&lt;',}.get(c, c) for c in comment)
+    comment = comment.replace('\n', '<br>') # make newlines html linebreaks
 
     # get users
     for i in re_user.finditer(comment):

--- a/crits/core/static/js/dialogs.js
+++ b/crits/core/static/js/dialogs.js
@@ -893,7 +893,12 @@ function update_dialog(e) {
 
     if (data_elem.length) { // some fields are set by default on page request and don't
                 // need to be set here set here
-        var value = data_elem.text();
+        if (field == 'comment') { // Only for editing comments
+            var value = data_elem.html(); // Get the HTML version
+            value = value.replace(/<br>/g, '\n'); // Preserve newlines
+        } else { //Everything else
+            var value = data_elem.text();
+        }
         if (field == 'action_type') {
             sel_val = value;
         }

--- a/extras/www/static/js/dialogs.js
+++ b/extras/www/static/js/dialogs.js
@@ -893,7 +893,12 @@ function update_dialog(e) {
 
     if (data_elem.length) { // some fields are set by default on page request and don't
                 // need to be set here set here
-        var value = data_elem.text();
+        if (field == 'comment') { // Only for editing comments
+            var value = data_elem.html(); // Get the HTML version
+            value = value.replace(/<br>/g, '\n'); // Preserve newlines
+        } else { //Everything else
+            var value = data_elem.text();
+        }
         if (field == 'action_type') {
             sel_val = value;
         }


### PR DESCRIPTION
If a user types a Comment containing newlines, those newlines are ignored when the Comment is displayed.  This converts the newline character `/n` to an html line break `<br>`, so that the intended newlines are displayed.