### PR TITLE
Limit length of Sample metadata "filetype" field

### DIFF
--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -103,6 +103,8 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
             pass
         try:
             self.filetype = magic.from_buffer(data)
+            if len(self.filetype) > 1000:
+                self.filetype = self.filetype[0:1000] + '<TRUNCATED>'
         except:
             self.filetype = "Unavailable"
         try:


### PR DESCRIPTION
In rare cases, the "magic" library can return a very long string for a Sample's `filetype` field. This results in an error because the value is too long for MongoDB to index.  Truncating the result at 1000 characters to make it fit.