### PR TITLE
Remove user management -A option from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR crits
 RUN TERM=xterm sh ./script/bootstrap < docker_inputs
 
 # Create a new admin. Username: "admin" , Password: "pass1PASS123!"
-RUN sh contrib/mongo/mongod_start.sh && python manage.py users -u admin -p "pass1PASS123!" -s -i -a -A -e admin@crits.crits -f "first" -l "last" -o "no-org"
+RUN sh contrib/mongo/mongod_start.sh && python manage.py users -R UberAdmin -u admin -p "pass1PASS123!" -s -i -a -e admin@crits.crits -f "first" -l "last" -o "no-org"
 
 EXPOSE 8080
 


### PR DESCRIPTION
### Remove user management -A option from Dockerfile

Error output from running the following *docker* command:```sudo docker build -t crits .```
```bash
Step 12/14 : RUN sh contrib/mongo/mongod_start.sh && python manage.py users -u admin -p "pass1PASS123!" -s -i -a -A -e admin@crits.crits -f "first" -l "last" -o "no-org"
 ---> Running in 2e3d47282b78
about to fork child process, waiting until server is ready for connections.
forked process: 8
child process started successfully, parent exiting
Usage: manage.py users [options]

Add and edit a CRITs user. If "-a" is not used, we will try to edit.            

manage.py: error: no such option: -A
```                                                                            

The *-A* option is no longer available in **crits/core/management/commands/users.py**

The *administrator* option was removed in the following commit:                                           
https://github.com/crits/crits/commit/e2841759963962232691c190c271e996c9c07af8#diff-765a9df987497a1c9d459265f139b80b

[alpha-7](https://github.com/alpha-7) mentions this error in issue *#909*: https://github.com/crits/crits/issues/909#issuecomment-305920657