### PR TITLE
Fix a corner case in only()

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -83,7 +83,9 @@ class CritsQuerySet(QS):
         Modified version of the default only() which allows
         us to add default fields we always want to include.
         """
-
+        # We don't need to modify the fields when None are passed
+        if not fields:
+            return super(CritsQuerySet, self).only(*fields)
         #Always include schema_version so we can migrate if needed.
         if 'schema_version' not in fields:
             fields = fields + ('schema_version',)


### PR DESCRIPTION
This change actually fixes the quirk that happens on newer versions of mongoengine.
There is an issue in CRITs' modified version of only(), it should just pass empty set of fileds without adding in schema_version in there when an empty set of fields is passed. This actually makes queries for audit_log and dashboard work as they should on mongoengine versions later than 0.8.x.

