### PR TITLE
Fix get_access_list() if user has no roles

### DIFF
--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -971,6 +971,9 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
 
         acl = {}
         roles = Role.objects(name__in=self.roles)
+        if not roles:
+            logger.error("No ROLES defined for user: {0}".format(self.username))
+            return False
         acl = roles.first()._data
 
         # for each role, modify the acl object to reflect all of the attributes


### PR DESCRIPTION
get_access_list() bombs out when an user has no roles assigned, this PR provides a fix and makes a note of it in the log.