### PR TITLE
Use pooled connection for pymongo based queries.

### DIFF
--- a/crits/core/mongo_tools.py
+++ b/crits/core/mongo_tools.py
@@ -23,7 +23,8 @@ class MongoError(Exception):
 def mongo_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
     """
     Connect to the mongo database if you need to use PyMongo directly and not
-    use MongoEngine.
+    use MongoEngine. Uses pooled connection created in settings.py rather than
+    opening a fresh connection every call.
 
     :param collection: the collection to use.
     :type collection: str
@@ -33,27 +34,15 @@ def mongo_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
               :class:`crits.core.mongo_tools.MongoError`
     """
 
-    try:
-        connection = pymongo.MongoClient("%s" % settings.MONGO_HOST,
-                                        settings.MONGO_PORT,
-                                        read_preference=preference,
-                                        ssl=settings.MONGO_SSL,
-					                   w=1) #, connect=False)
-        db = connection[settings.MONGO_DATABASE]
-        if settings.MONGO_USER:
-            db.authenticate(settings.MONGO_USER, settings.MONGO_PASSWORD)
-        return db[collection]
-    except pymongo.errors.ConnectionFailure as e:
-        raise MongoError("Error connecting to Mongo database: %s" % e)
-    except KeyError as e:
-        raise MongoError("Unknown database or collection: %s" % e)
-    except Exception as e:
-        raise MongoError("MongoError: %s" % e)
+    return settings.PY_DB[collection]
 
 def gridfs_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
     """
     Connect to the mongo database if you need to use PyMongo directly and not
-    use MongoEngine. Used specifically for accessing GridFS.
+    use MongoEngine. Uses pooled connection created in settings.py rather than
+    opening a fresh connection every call.
+    
+    Used specifically for accessing GridFS.
 
     :param collection: the collection to use.
     :type collection: str
@@ -63,24 +52,7 @@ def gridfs_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
               :class:`crits.core.mongo_tools.MongoError`
     """
 
-    try:
-        # w=0 writes to GridFS are now prohibited.
-        #if pymongo.version_tuple >=(3,0):
-        connection = pymongo.MongoClient("%s" % settings.MONGO_HOST,
-                                        settings.MONGO_PORT,
-                                        read_preference=preference,
-                                        ssl=settings.MONGO_SSL,
-                                        w=1) #, connect=False)
-        db = connection[settings.MONGO_DATABASE]
-        if settings.MONGO_USER:
-            db.authenticate(settings.MONGO_USER, settings.MONGO_PASSWORD)
-        return gridfs.GridFS(db, collection)
-    except pymongo.errors.ConnectionFailure as e:
-        raise MongoError("Error connecting to Mongo database: %s" % e)
-    except KeyError as e:
-        raise MongoError("Unknown database: %s" % e)
-    except Exception as e:
-        raise MongoError("MongoError: %s" % e)
+    return gridfs.GridFS(settings.PY_DB, collection)
 
 def get_file(sample_md5, collection=settings.COL_SAMPLES):
     """

--- a/crits/core/mongo_tools.py
+++ b/crits/core/mongo_tools.py
@@ -34,7 +34,10 @@ def mongo_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
               :class:`crits.core.mongo_tools.MongoError`
     """
 
-    return settings.PY_DB[collection]
+    try:
+        return settings.PY_DB[collection]
+    except Exception as e:
+        raise MongoError("MongoError: %s" % e)
 
 def gridfs_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
     """
@@ -52,7 +55,10 @@ def gridfs_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
               :class:`crits.core.mongo_tools.MongoError`
     """
 
-    return gridfs.GridFS(settings.PY_DB, collection)
+    try:
+        return gridfs.GridFS(settings.PY_DB, collection)
+    except Exception as e:
+        raise MongoError("MongoError: %s" % e)
 
 def get_file(sample_md5, collection=settings.COL_SAMPLES):
     """

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -10,7 +10,6 @@ import subprocess
 from pymongo import ReadPreference, MongoClient
 from mongoengine import connect
 from mongoengine import __version__ as mongoengine_version
-from pymongo import version_tuple as pymongo_versiont
 
 from distutils.version import StrictVersion
 
@@ -201,15 +200,21 @@ else:
     connect(MONGO_DATABASE, host=MONGO_HOST, port=MONGO_PORT, read_preference=MONGO_READ_PREFERENCE, ssl=MONGO_SSL,
             replicaset=MONGO_REPLICASET)
 
-# Get config from DB
-if pymongo_versiont >=(3,0):
-    c = MongoClient(MONGO_HOST, MONGO_PORT, ssl=MONGO_SSL, w=0) #, connect=False)
-else:
-    c = MongoClient(MONGO_HOST, MONGO_PORT, ssl=MONGO_SSL, w=0)
-db = c[MONGO_DATABASE]
-if MONGO_USER:
-    db.authenticate(MONGO_USER, MONGO_PASSWORD)
-coll = db[COL_CONFIG]
+# Get config from DB via pymongo
+def connect_pymongo(dbs=MONGO_DATABASE, dbhost=MONGO_HOST, dbport=MONGO_PORT, dbuser=MONGO_USER, dbpass=MONGO_PASSWORD, dbssl=MONGO_SSL, w=0):
+    from pymongo import version_tuple as pymongo_versiont
+    if pymongo_versiont >= (3,0):
+        c = MongoClient(dbhost, dbport, ssl=dbssl, w=w) #, connect=False)
+    else:
+        c = MongoClient(dbhost, dbport, ssl=dbssl, w=w)
+    dbase = c[dbs]
+    if dbuser:
+        dbase.authenticate(dbuser, dbpass)
+    return dbase
+
+PY_DB = connect_pymongo(MONGO_DATABASE, MONGO_HOST, MONGO_PORT, MONGO_USER, MONGO_PASSWORD, MONGO_SSL, 0)
+
+coll = PY_DB[COL_CONFIG]
 crits_config = coll.find_one({})
 if not crits_config:
     crits_config = {}

--- a/crits/settings.py
+++ b/crits/settings.py
@@ -201,7 +201,7 @@ else:
             replicaset=MONGO_REPLICASET)
 
 # Get config from DB via pymongo
-def connect_pymongo(dbs=MONGO_DATABASE, dbhost=MONGO_HOST, dbport=MONGO_PORT, dbuser=MONGO_USER, dbpass=MONGO_PASSWORD, dbssl=MONGO_SSL, w=0):
+def connect_pymongo(dbs=MONGO_DATABASE, dbhost=MONGO_HOST, dbport=MONGO_PORT, dbuser=MONGO_USER, dbpass=MONGO_PASSWORD, dbssl=MONGO_SSL, w=1):
     from pymongo import version_tuple as pymongo_versiont
     if pymongo_versiont >= (3,0):
         c = MongoClient(dbhost, dbport, ssl=dbssl, w=w) #, connect=False)
@@ -212,7 +212,7 @@ def connect_pymongo(dbs=MONGO_DATABASE, dbhost=MONGO_HOST, dbport=MONGO_PORT, db
         dbase.authenticate(dbuser, dbpass)
     return dbase
 
-PY_DB = connect_pymongo(MONGO_DATABASE, MONGO_HOST, MONGO_PORT, MONGO_USER, MONGO_PASSWORD, MONGO_SSL, 0)
+PY_DB = connect_pymongo(MONGO_DATABASE, MONGO_HOST, MONGO_PORT, MONGO_USER, MONGO_PASSWORD, MONGO_SSL, 1)
 
 coll = PY_DB[COL_CONFIG]
 crits_config = coll.find_one({})


### PR DESCRIPTION
http://api.mongodb.com/python/current/faq.html#how-does-connection-pooling-work-in-pymongo

One connection is established in settings.py, and now is used in
mongo_connector() and gridfs_connector(). Previously, every call
was opening a brand new connection to the database.