### PR TITLE
Try to avoid issues with pymongo and connection pooling 

### DIFF
--- a/crits/campaigns/handlers.py
+++ b/crits/campaigns/handlers.py
@@ -18,7 +18,7 @@ from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.crits_mongoengine import EmbeddedCampaign, json_handler
 from crits.core.handlers import jtable_ajax_list, build_jtable
 from crits.core.handlers import csv_export, get_item_names
-from crits.core.mongo_tools import mongo_connector
+from crits.core.mongo_tools import _mongo_connector
 from crits.core.user_tools import user_sources, is_user_subscribed
 from crits.core.user_tools import is_user_favorite
 from crits.notifications.handlers import remove_user_from_notification
@@ -143,7 +143,7 @@ def get_campaign_stats(campaign):
 
     # The Statistics collection has a bunch of documents which are not
     # in the same format, so we can't class it at this time.
-    stats = mongo_connector(settings.COL_STATISTICS)
+    stats = _mongo_connector(settings.COL_STATISTICS)
     stat = stats.find_one({"name": "campaign_monthly"})
     data_list = []
     if stat:

--- a/crits/certificates/certificate.py
+++ b/crits/certificates/certificate.py
@@ -114,9 +114,9 @@ class Certificate(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument
         Queries GridFS for a matching binary to this Certificate document.
         """
 
-        from crits.core.mongo_tools import mongo_connector
+        from crits.core.mongo_tools import _mongo_connector
 
-        fm = mongo_connector("%s.files" % self._meta['collection'])
+        fm = _mongo_connector("%s.files" % self._meta['collection'])
         objectid = fm.find_one({'md5': self.md5}, {'_id': 1})
         if objectid:
             self.filedata.grid_id = objectid['_id']

--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -16,7 +16,7 @@ from hashlib import md5
 
 from crits.core.class_mapper import class_from_value
 from crits.core.exceptions import ZipFileError
-from crits.core.mongo_tools import get_file
+from crits.core.mongo_tools import _get_file
 
 def get_file_fs(sample_md5):
     """
@@ -348,7 +348,7 @@ def make_ascii_strings(md5=None, data=None):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     strings_data = 'ASCII Strings\n'
     strings_data += "-" * 30
     strings_data += "\n"
@@ -369,7 +369,7 @@ def make_unicode_strings(md5=None, data=None):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     strings_data = 'Unicode Strings\n'
     strings_data += "-" * 30
     strings_data += "\n"
@@ -390,7 +390,7 @@ def make_stackstrings(md5=None, data=None):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     x = 0
     prev = 0
     strings = ''
@@ -428,7 +428,7 @@ def make_hex(md5=None, data=None):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     length = 16
     hex_data = ''
     digits = 4 if isinstance(data, unicode) else 2
@@ -455,7 +455,7 @@ def xor_string(md5=None, data=None, key=0, null=0):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     out = ''
     for c in data:
         if ord(c) == 0 and null == 1:
@@ -484,7 +484,7 @@ def xor_search(md5=None, data=None, string=None, skip_nulls=0):
     """
 
     if md5:
-        data = get_file(md5)
+        data = _get_file(md5)
     if string is None or string == '':
         plaintext_list = [
                         'This program',

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -45,7 +45,7 @@ from crits.core.crits_mongoengine import CritsSourceDocument
 from crits.core.crits_mongoengine import EmbeddedPreferredAction
 from crits.core.source_access import SourceAccess
 from crits.core.data_tools import create_zip, format_file
-from crits.core.mongo_tools import mongo_connector, get_file
+from crits.core.mongo_tools import _mongo_connector, _get_file
 from crits.core.role import Role
 from crits.core.sector import Sector
 from crits.core.user import CRITsUser, EmbeddedSubscriptions
@@ -979,10 +979,10 @@ def alter_bucket_list(obj, buckets, val):
     soi = { k: 0 for k in Bucket._meta['schema_doc'].keys() if k != 'name' and k != obj._meta['crits_type'] }
     soi['schema_version'] = Bucket._meta['latest_schema_version']
 
-    # We are using mongo_connector here because mongoengine does not have
+    # We are using _mongo_connector here because mongoengine does not have
     # support for a setOnInsert option. If mongoengine were to gain support
     # for this we should switch to using it instead of pymongo here.
-    buckets_col = mongo_connector(settings.COL_BUCKET_LISTS)
+    buckets_col = _mongo_connector(settings.COL_BUCKET_LISTS)
     for name in buckets:
         buckets_col.update({'name': name},
                            {'$inc': {obj._meta['crits_type']: val},
@@ -3740,36 +3740,36 @@ def download_grid_file(request, dtype, sample_md5):
     """
 
     if dtype == 'object':
-        grid = mongo_connector("%s.files" % settings.COL_OBJECTS)
+        grid = _mongo_connector("%s.files" % settings.COL_OBJECTS)
         obj = grid.find_one({'md5': sample_md5})
         if obj is None:
             dtype = 'pcap'
         else:
-            data = [(obj['filename'], get_file(sample_md5, "objects"))]
+            data = [(obj['filename'], _get_file(sample_md5, "objects"))]
             zip_data = create_zip(data, False)
             response = HttpResponse(zip_data, content_type="application/octet-stream")
             response['Content-Disposition'] = 'attachment; filename=%s' % obj['filename'] + ".zip"
             return response
     if dtype == 'pcap':
-        pcaps = mongo_connector(settings.COL_PCAPS)
+        pcaps = _mongo_connector(settings.COL_PCAPS)
         pcap = pcaps.find_one({"md5": sample_md5})
         if not pcap:
             return render(request, 'error.html',
                                       {'data': request,
                                        'error': "File not found."})
-        data = [(pcap['filename'], get_file(sample_md5, "pcaps"))]
+        data = [(pcap['filename'], _get_file(sample_md5, "pcaps"))]
         zip_data = create_zip(data, False)
         response = HttpResponse(zip_data, content_type="application/octet-stream")
         response['Content-Disposition'] = 'attachment; filename=%s' % pcap['filename'] + ".zip"
         return response
     if dtype == 'cert':
-        certificates = mongo_connector(settings.COL_CERTIFICATES)
+        certificates = _mongo_connector(settings.COL_CERTIFICATES)
         cert = certificates.find_one({"md5": sample_md5})
         if not cert:
             return render(request, 'error.html',
                                       {'data': request,
                                        'error': "File not found."})
-        data = [(cert['filename'], get_file(sample_md5, "certificates"))]
+        data = [(cert['filename'], _get_file(sample_md5, "certificates"))]
         zip_data = create_zip(data, False)
         response = HttpResponse(zip_data, content_type="application/octet-stream")
         response['Content-Disposition'] = 'attachment; filename=%s' % cert['filename'] + ".zip"
@@ -3788,7 +3788,7 @@ def generate_counts_jtable(request, option):
     """
 
     if option == "jtlist":
-        count = mongo_connector(settings.COL_COUNTS)
+        count = _mongo_connector(settings.COL_COUNTS)
         counts = count.find_one({'name': 'counts'})
         response = {}
         response['Result'] = "OK"
@@ -4149,10 +4149,10 @@ def alter_sector_list(obj, sectors, val):
     soi = { k: 0 for k in Sector._meta['schema_doc'].keys() if k != 'name' and k != obj._meta['crits_type'] }
     soi['schema_version'] = Sector._meta['latest_schema_version']
 
-    # We are using mongo_connector here because mongoengine does not have
+    # We are using _mongo_connector here because mongoengine does not have
     # support for a setOnInsert option. If mongoengine were to gain support
     # for this we should switch to using it instead of pymongo here.
-    sectors_col = mongo_connector(settings.COL_SECTOR_LISTS)
+    sectors_col = _mongo_connector(settings.COL_SECTOR_LISTS)
     for name in sectors:
         sectors_col.update({'name': name},
                            {'$inc': {obj._meta['crits_type']: val},

--- a/crits/core/management/commands/create_indexes.py
+++ b/crits/core/management/commands/create_indexes.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 
-from crits.core.mongo_tools import mongo_connector
+from crits.core.mongo_tools import _mongo_connector
 
 class Command(BaseCommand):
     """
@@ -67,7 +67,7 @@ def remove_indexes():
 
     for coll in coll_list:
         print "Removing index for: %s" % coll
-        c = mongo_connector(coll)
+        c = _mongo_connector(coll)
         c.drop_indexes()
 
 def create_indexes():
@@ -79,7 +79,7 @@ def create_indexes():
 
     print "Creating indexes (duplicates will be ignored automatically)"
 
-    analysis_results = mongo_connector(settings.COL_ANALYSIS_RESULTS)
+    analysis_results = _mongo_connector(settings.COL_ANALYSIS_RESULTS)
     analysis_results.create_index("service_name", background=True)
     analysis_results.create_index("object_type", background=True)
     analysis_results.create_index("object_id", background=True)
@@ -88,31 +88,31 @@ def create_indexes():
     analysis_results.create_index("version", background=True)
     analysis_results.create_index("analysis_id", background=True)
 
-    bucket_lists = mongo_connector(settings.COL_BUCKET_LISTS)
+    bucket_lists = _mongo_connector(settings.COL_BUCKET_LISTS)
     bucket_lists.create_index("name", background=True)
 
-    backdoors = mongo_connector(settings.COL_BACKDOORS)
+    backdoors = _mongo_connector(settings.COL_BACKDOORS)
     backdoors.create_index("name", background=True)
 
-    campaigns = mongo_connector(settings.COL_CAMPAIGNS)
+    campaigns = _mongo_connector(settings.COL_CAMPAIGNS)
     campaigns.create_index("objects.value", background=True)
     campaigns.create_index("relationships.value", background=True)
     campaigns.create_index("bucket_list", background=True)
 
-    comments = mongo_connector(settings.COL_COMMENTS)
+    comments = _mongo_connector(settings.COL_COMMENTS)
     comments.create_index("obj_id", background=True)
     comments.create_index("users", background=True)
     comments.create_index("tags", background=True)
     comments.create_index("status", background=True)
 
-    domains = mongo_connector(settings.COL_DOMAINS)
+    domains = _mongo_connector(settings.COL_DOMAINS)
     domains.create_index("domain", background=True)
     domains.create_index("objects.value", background=True)
     domains.create_index("relationships.value", background=True)
     domains.create_index("campaign.name", background=True)
     domains.create_index("bucket_list", background=True)
 
-    emails = mongo_connector(settings.COL_EMAIL)
+    emails = _mongo_connector(settings.COL_EMAIL)
     emails.create_index("objects.value", background=True)
     emails.create_index("relationships.value", background=True)
     emails.create_index("campaign.name", background=True)
@@ -124,7 +124,7 @@ def create_indexes():
     emails.create_index("subject", background=True)
     emails.create_index("isodate", background=True)
 
-    events = mongo_connector(settings.COL_EVENTS)
+    events = _mongo_connector(settings.COL_EVENTS)
     events.create_index("objects.value", background=True)
     events.create_index("title", background=True)
     events.create_index("relationships.value", background=True)
@@ -136,10 +136,10 @@ def create_indexes():
     events.create_index("event_type", background=True)
     events.create_index("bucket_list", background=True)
 
-    exploits = mongo_connector(settings.COL_EXPLOITS)
+    exploits = _mongo_connector(settings.COL_EXPLOITS)
     exploits.create_index("name", background=True)
 
-    indicators = mongo_connector(settings.COL_INDICATORS)
+    indicators = _mongo_connector(settings.COL_INDICATORS)
     indicators.create_index("value", background=True)
     indicators.create_index("lower", background=True)
     indicators.create_index("objects.value", background=True)
@@ -152,7 +152,7 @@ def create_indexes():
     indicators.create_index("source.name", background=True)
     indicators.create_index("bucket_list", background=True)
 
-    ips = mongo_connector(settings.COL_IPS)
+    ips = _mongo_connector(settings.COL_IPS)
     ips.create_index("ip", background=True)
     ips.create_index("objects.value", background=True)
     ips.create_index("relationships.value", background=True)
@@ -166,22 +166,22 @@ def create_indexes():
     ips.create_index("bucket_list", background=True)
 
     if settings.FILE_DB == settings.GRIDFS:
-        objects_files = mongo_connector('%s.files' % settings.COL_OBJECTS)
+        objects_files = _mongo_connector('%s.files' % settings.COL_OBJECTS)
         objects_files.create_index("md5", background=True)
 
-        objects_chunks = mongo_connector('%s.chunks' % settings.COL_OBJECTS)
+        objects_chunks = _mongo_connector('%s.chunks' % settings.COL_OBJECTS)
         objects_chunks.create_index([("files_id",pymongo.ASCENDING),
                                 ("n", pymongo.ASCENDING)],
                                unique=True)
 
-    notifications = mongo_connector(settings.COL_NOTIFICATIONS)
+    notifications = _mongo_connector(settings.COL_NOTIFICATIONS)
     notifications.create_index("obj_id", background=True)
     # auto-expire notifications after 30 days
     notifications.create_index("date", background=True,
                                expireAfterSeconds=2592000)
     notifications.create_index("users", background=True)
 
-    pcaps = mongo_connector(settings.COL_PCAPS)
+    pcaps = _mongo_connector(settings.COL_PCAPS)
     pcaps.create_index("md5", background=True)
     pcaps.create_index("objects.value", background=True)
     pcaps.create_index("relationships.value", background=True)
@@ -196,15 +196,15 @@ def create_indexes():
     pcaps.create_index("bucket_list", background=True)
 
     if settings.FILE_DB == settings.GRIDFS:
-        pcaps_files = mongo_connector('%s.files' % settings.COL_PCAPS)
+        pcaps_files = _mongo_connector('%s.files' % settings.COL_PCAPS)
         pcaps_files.create_index("md5", background=True)
 
-        pcaps_chunks = mongo_connector('%s.chunks' % settings.COL_PCAPS)
+        pcaps_chunks = _mongo_connector('%s.chunks' % settings.COL_PCAPS)
         pcaps_chunks.create_index([("files_id", pymongo.ASCENDING),
                                 ("n", pymongo.ASCENDING)],
                                unique=True)
 
-    raw_data = mongo_connector(settings.COL_RAW_DATA)
+    raw_data = _mongo_connector(settings.COL_RAW_DATA)
     raw_data.create_index("link_id", background=True)
     raw_data.create_index("md5", background=True)
     raw_data.create_index("title", background=True)
@@ -219,7 +219,7 @@ def create_indexes():
     raw_data.create_index("favorite", background=True)
     raw_data.create_index("bucket_list", background=True)
 
-    samples = mongo_connector(settings.COL_SAMPLES)
+    samples = _mongo_connector(settings.COL_SAMPLES)
     samples.create_index("source.name", background=True)
     samples.create_index("md5", background=True)
     samples.create_index("sha1", background=True)
@@ -242,18 +242,18 @@ def create_indexes():
     samples.create_index("status", background=True)
 
     if settings.FILE_DB == settings.GRIDFS:
-        samples_files = mongo_connector('%s.files' % settings.COL_SAMPLES)
+        samples_files = _mongo_connector('%s.files' % settings.COL_SAMPLES)
         samples_files.create_index("md5", background=True)
 
-        samples_chunks = mongo_connector('%s.chunks' % settings.COL_SAMPLES)
+        samples_chunks = _mongo_connector('%s.chunks' % settings.COL_SAMPLES)
         samples_chunks.create_index([("files_id", pymongo.ASCENDING),
                                   ("n", pymongo.ASCENDING)],
                                  unique=True)
 
-    screenshots = mongo_connector(settings.COL_SCREENSHOTS)
+    screenshots = _mongo_connector(settings.COL_SCREENSHOTS)
     screenshots.create_index("tags", background=True)
 
-    signature = mongo_connector(settings.COL_SIGNATURES)
+    signature = _mongo_connector(settings.COL_SIGNATURES)
     signature.create_index("link_id", background=True)
     signature.create_index("md5", background=True)
     signature.create_index("title", background=True)
@@ -271,7 +271,7 @@ def create_indexes():
     signature.create_index("favorite", background=True)
     signature.create_index("bucket_list", background=True)
 
-    targets = mongo_connector(settings.COL_TARGETS)
+    targets = _mongo_connector(settings.COL_TARGETS)
     targets.create_index("objects.value", background=True)
     targets.create_index("relationships.value", background=True)
     targets.create_index("email_address", background=True)

--- a/crits/core/management/commands/create_roles.py
+++ b/crits/core/management/commands/create_roles.py
@@ -195,10 +195,10 @@ def migrate_roles():
     Migrate legacy role objects to new RBAC Role objects
 
     """
-    from crits.core.mongo_tools import mongo_connector
+    from crits.core.mongo_tools import _mongo_connector
     import sys
 
-    collection = mongo_connector(settings.COL_USERS)
+    collection = _mongo_connector(settings.COL_USERS)
     users = collection.find()
 
     for user in users:

--- a/crits/core/management/commands/prep.py
+++ b/crits/core/management/commands/prep.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from crits.config.config import CRITsConfig
-from crits.core.mongo_tools import mongo_update, mongo_remove, mongo_connector
+from crits.core.mongo_tools import mongo_update, mongo_remove, _mongo_connector
 
 
 

--- a/crits/core/mongo_tools.py
+++ b/crits/core/mongo_tools.py
@@ -16,7 +16,7 @@ class MongoError(Exception):
     """
     pass
 
-# TODO: _mongo_connector() and gridfs_connector() can probably be combined into
+# TODO: mongo_connector() and gridfs_connector() can probably be combined into
 # one function.
 def mongo_connector(collection, preference=settings.MONGO_READ_PREFERENCE):
     """
@@ -239,7 +239,7 @@ def _put_file(m, data, collection=settings.COL_SAMPLES):
     :returns: str
     """
 
-    return put_file_gridfs(m, data, collection)
+    return _put_file_gridfs(m, data, collection)
 
 def _get_file_gridfs(sample_md5, collection=settings.COL_SAMPLES):
     """

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -13,7 +13,7 @@ from crits.core import form_consts
 from crits.core.class_mapper import class_from_id, class_from_type
 from crits.core.data_tools import convert_string_to_bool, detect_pcap
 from crits.core.handsontable_tools import form_to_dict, get_field_from_label
-from crits.core.mongo_tools import put_file, mongo_connector
+from crits.core.mongo_tools import put_file, _mongo_connector
 from crits.core.user_tools import get_user_organization
 from crits.indicators.indicator import Indicator
 from crits.objects.forms import AddObjectForm
@@ -291,7 +291,7 @@ def add_object(type_, id_, object_type, source, method, reference, tlp, user,
                 #XXX: MongoEngine provides no direct GridFS access so we
                 #     need to use pymongo directly.
                 col = settings.COL_OBJECTS
-                grid = mongo_connector("%s.files" % col)
+                grid = _mongo_connector("%s.files" % col)
                 if grid.find({'md5': md5sum}).count() == 0:
                     put_file(filename, data, collection=col)
 
@@ -373,7 +373,7 @@ def delete_object_file(value):
             break
     else:
         col = settings.COL_OBJECTS
-        grid = mongo_connector("%s.files" % col)
+        grid = _mongo_connector("%s.files" % col)
         grid.remove({'md5': value})
     return
 

--- a/crits/pcaps/pcap.py
+++ b/crits/pcaps/pcap.py
@@ -119,9 +119,9 @@ class PCAP(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
         Queries GridFS for a matching binary to this pcap document.
         """
 
-        from crits.core.mongo_tools import mongo_connector
+        from crits.core.mongo_tools import _mongo_connector
 
-        fm = mongo_connector("%s.files" % self._meta['collection'])
+        fm = _mongo_connector("%s.files" % self._meta['collection'])
         objectid = fm.find_one({'md5': self.md5}, {'_id': 1})
         if objectid:
             self.filedata.grid_id = objectid['_id']

--- a/crits/samples/sample.py
+++ b/crits/samples/sample.py
@@ -171,9 +171,9 @@ class Sample(CritsBaseAttributes, CritsSourceDocument, CritsActionsDocument,
             Queries GridFS for a matching binary to this sample document.
         """
 
-        from crits.core.mongo_tools import mongo_connector
+        from crits.core.mongo_tools import _mongo_connector
 
-        fm = mongo_connector("%s.files" % self._meta['collection'])
+        fm = _mongo_connector("%s.files" % self._meta['collection'])
         objectid = fm.find_one({'md5': self.md5}, {'_id': 1})
         if objectid:
             self.filedata.grid_id = objectid['_id']

--- a/crits/stats/handlers.py
+++ b/crits/stats/handlers.py
@@ -2,7 +2,7 @@ from bson import Code
 import datetime
 
 from django.conf import settings
-from crits.core.mongo_tools import mongo_connector
+from crits.core.mongo_tools import _mongo_connector
 
 from crits.emails.email import Email
 from crits.samples.yarahit import YaraHit
@@ -14,7 +14,7 @@ def generate_yara_hits():
     Generate yara hits mapreduce.
     """
 
-    samples = mongo_connector(settings.COL_SAMPLES)
+    samples = _mongo_connector(settings.COL_SAMPLES)
     map_code = """
     function() {
             this.analysis.forEach(function(z) {
@@ -33,7 +33,7 @@ def generate_yara_hits():
                                              query={'analysis.service_name': 'yara'})
     except:
         return
-    yarahits_col = mongo_connector(settings.COL_YARAHITS)
+    yarahits_col = _mongo_connector(settings.COL_YARAHITS)
     yarahits_col.drop()
     sv = YaraHit._meta['latest_schema_version']
     for hit in yarahits:
@@ -50,7 +50,7 @@ def generate_sources():
     Generate sources mapreduce.
     """
 
-    samples = mongo_connector(settings.COL_SAMPLES)
+    samples = _mongo_connector(settings.COL_SAMPLES)
     m = Code('function() { this.source.forEach(function(z) {emit({name: z.name}, {count: 1});}) }', {})
     r = Code('function(k,v) { var count=0; v.forEach(function(v) { count += v["count"]; }); return {count: count}; }', {})
     try:
@@ -58,7 +58,7 @@ def generate_sources():
                                             query={"source.name": {"$exists": 1}})
     except:
         return
-    source_access = mongo_connector(settings.COL_SOURCE_ACCESS)
+    source_access = _mongo_connector(settings.COL_SOURCE_ACCESS)
     for source in sources:
         source_access.update({"name": source["_id"]["name"]},
                              {"$set": {"sample_count": source["value"]["count"]}})
@@ -68,7 +68,7 @@ def generate_filetypes():
     Generate filetypes mapreduce.
     """
 
-    samples = mongo_connector(settings.COL_SAMPLES)
+    samples = _mongo_connector(settings.COL_SAMPLES)
     m = Code('function() emit({filetype: this.mimetype} ,{count: 1});}) }', {})
     r = Code('function(k,v) { var count = 0; v.forEach(function(v) { count += v["count"]; }); return {count: count}; }', {})
     try:
@@ -135,17 +135,17 @@ def generate_campaign_stats(source_name=None):
     stat_query["campaign.name"] = {"$exists": "true"}
     if source_name:
         stat_query["source.name"] = source_name
-    actors = mongo_connector(settings.COL_ACTORS)
-    backdoors = mongo_connector(settings.COL_BACKDOORS)
-    campaigns = mongo_connector(settings.COL_CAMPAIGNS)
-    domains = mongo_connector(settings.COL_DOMAINS)
-    emails = mongo_connector(settings.COL_EMAIL)
-    events = mongo_connector(settings.COL_EVENTS)
-    exploits = mongo_connector(settings.COL_EXPLOITS)
-    indicators = mongo_connector(settings.COL_INDICATORS)
-    ips = mongo_connector(settings.COL_IPS)
-    pcaps = mongo_connector(settings.COL_PCAPS)
-    samples = mongo_connector(settings.COL_SAMPLES)
+    actors = _mongo_connector(settings.COL_ACTORS)
+    backdoors = _mongo_connector(settings.COL_BACKDOORS)
+    campaigns = _mongo_connector(settings.COL_CAMPAIGNS)
+    domains = _mongo_connector(settings.COL_DOMAINS)
+    emails = _mongo_connector(settings.COL_EMAIL)
+    events = _mongo_connector(settings.COL_EVENTS)
+    exploits = _mongo_connector(settings.COL_EXPLOITS)
+    indicators = _mongo_connector(settings.COL_INDICATORS)
+    ips = _mongo_connector(settings.COL_IPS)
+    pcaps = _mongo_connector(settings.COL_PCAPS)
+    samples = _mongo_connector(settings.COL_SAMPLES)
     # generate an initial campaign listing so we can make sure all campaigns get updated
     campaign_listing = campaigns.find({}, {'name': 1})
     # initialize each campaign to zeroed out stats
@@ -193,12 +193,12 @@ def generate_counts():
     Generate dashboard counts.
     """
 
-    counts = mongo_connector(settings.COL_COUNTS)
-    samples = mongo_connector(settings.COL_SAMPLES)
-    emails = mongo_connector(settings.COL_EMAIL)
-    indicators = mongo_connector(settings.COL_INDICATORS)
-    domains = mongo_connector(settings.COL_DOMAINS)
-    pcaps = mongo_connector(settings.COL_PCAPS)
+    counts = _mongo_connector(settings.COL_COUNTS)
+    samples = _mongo_connector(settings.COL_SAMPLES)
+    emails = _mongo_connector(settings.COL_EMAIL)
+    indicators = _mongo_connector(settings.COL_INDICATORS)
+    domains = _mongo_connector(settings.COL_DOMAINS)
+    pcaps = _mongo_connector(settings.COL_PCAPS)
     today = datetime.datetime.fromordinal(datetime.datetime.now().toordinal())
     start = datetime.datetime.now()
     last_seven = start - datetime.timedelta(7)
@@ -287,7 +287,7 @@ def campaign_date_stats():
     Generate Campaign date stats.
     """
 
-    emails = mongo_connector(settings.COL_EMAIL)
+    emails = _mongo_connector(settings.COL_EMAIL)
     mapcode = """
             function () {
                     try {
@@ -325,7 +325,7 @@ def campaign_date_stats():
     m = Code(mapcode, {})
     r = Code(reducecode, {})
     results = emails.inline_map_reduce(m, r)
-    stat_coll = mongo_connector(settings.COL_STATISTICS)
+    stat_coll = _mongo_connector(settings.COL_STATISTICS)
     stats = {}
     stats["results"] = []
     for result in results:


### PR DESCRIPTION
This PR extends #978, and tries to avoid issues with pymongo and connection pooling when SERVICE_MODEL is using multiprocessing. More details are at: http://api.mongodb.com/python/current/faq.html#using-pymongo-with-multiprocessing.

Internal queries in CRITs now go through the new internal functions _mongo_connector() and _gridfs_connector() in mongo_tools.py, and the other few functions are implemented, so that they take advantage of the persistent connection to the database.

The old functions are modified so that depending on the SERVICE_MODEL they either kick off the separate connections (for process or process_pool) or otherwise the persistent connection is used.

These changes should make the things transparent for the services, and route the core's queries through the persistent connection.