### PR TITLE
Handle non-ASCII in changed field notifications

### DIFF
--- a/crits/notifications/processor.py
+++ b/crits/notifications/processor.py
@@ -109,9 +109,15 @@ class ChangeParser():
 
         message = ""
         if len(added_names) > 0:
-            message += "Added to %s: %s. " % (changed_field, unicode(', '.join(added_names)))
+            added_names = ', '.join(added_names)
+            if not isinstance(added_names, unicode):
+                added_names = unicode(added_names, 'utf-8', 'replace')
+            message += "Added to %s: %s. " % (changed_field, added_names)
         if len(removed_names) > 0:
-            message += "Removed from %s: %s. " % (changed_field, unicode(', '.join(removed_names)))
+            removed_names = ', '.join(removed_names)
+            if not isinstance(removed_names, unicode):
+                removed_names = unicode(removed_names, 'utf-8', 'replace')
+            message += "Removed from %s: %s. " % (changed_field, removed_names)
 
         return message
 
@@ -135,9 +141,15 @@ class ChangeParser():
 
         message = ""
         if len(added_names) > 0:
-            message += "Added to %s: %s. " % (changed_field, unicode(', '.join(added_names)))
+            added_names = ', '.join(added_names)
+            if not isinstance(added_names, unicode):
+                added_names = unicode(added_names, 'utf-8', 'replace')
+            message += "Added to %s: %s. " % (changed_field, added_names)
         if len(removed_names) > 0:
-            message += "Removed from %s: %s. " % (changed_field, unicode(', '.join(removed_names)))
+            removed_names = ', '.join(removed_names)
+            if not isinstance(removed_names, unicode):
+                removed_names = unicode(removed_names, 'utf-8', 'replace')
+            message += "Removed from %s: %s. " % (changed_field, removed_names)
 
         return message
 
@@ -346,7 +358,9 @@ class ChangeParser():
 
     @staticmethod
     def raw_data_highlights_summary_handler(object):
-        return "line %s: %s" % (object.line, unicode(object.line_data))
+        if not isinstance(object.line_data, unicode):
+            line_data = unicode(object.line_data, 'utf-8', 'replace')
+        return "line %s: %s" % (object.line, line_data)
 
     @staticmethod
     def raw_data_inlines_summary_handler(object):


### PR DESCRIPTION
Modifying a TLO leads to the generation of an audit notification listing which fields were changed, and in the case of a list field, which values were added/removed.  These values are forced to Unicode, but no encoding is given. If the added/removed values contain non-ASCII characters, the Unicode Decode fails. This fix tells it to use UTF-8.