### PR TITLE
Attempt to fix performance problem raised in Issue #913

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -538,6 +538,8 @@ class CRITsAPIResource(MongoEngineResource):
         if no_sources and sources:
             querydict['source.name'] = {'$in': source_list}
 
+        querydict_tlp_filter = user.filter_dict_source_tlp(querydict)
+
         if only or exclude:
             required = [k for k,f in klass._fields.iteritems() if f.required]
         if only:
@@ -548,28 +550,28 @@ class CRITsAPIResource(MongoEngineResource):
             for r in required:
                 if r not in fields:
                     fields.append(r)
-            results = klass.objects(__raw__=querydict).only(*fields)
+            results = klass.objects(__raw__=querydict_tlp_filter).only(*fields)
         elif exclude:
             fields = exclude.split(',')
             for r in required:
                 if r not in fields:
                     fields.append(r)
-            results = klass.objects(__raw__=querydict).exclude(*fields)
+            results = klass.objects(__raw__=querydict_tlp_filter).exclude(*fields)
         else:
-            results = klass.objects(__raw__=querydict)
+            results = klass.objects(__raw__=querydict_tlp_filter)
 
         # There has to be a better way to do this...
         # Final scrub to remove results the user does not have access to
-        id_list = []
+        #id_list = []
 
-        if not klass._meta['crits_type']:
-            return results
+        #if not klass._meta['crits_type']:
+        #    return results
 
-        for result in results:
-            if user.check_source_tlp(result):
-                id_list.append(result.id)
+        #for result in results:
+        #    if user.check_source_tlp(result):
+        #        id_list.append(result.id)
 
-        results = klass.objects(id__in=id_list)
+        #results = klass.objects(id__in=id_list)
 
         return results
 

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2025,21 +2025,27 @@ def data_query(col_obj, user, limit=25, skip=0, sort=[], query={},
         # Else, all other objects that have sources associated with them
         # need to be filtered appropriately for source access and TLP access
         else:
-            fily = {'id': 1, 'tlp':1,'source':1}
-            filterlist = []
-            query['source.name'] = {'$in': sourcefilt}
-            resy = col.find(query, fily).sort(*sort)
-            for r in resy:
-                if user.check_dict_source_tlp(r):
-                    filterlist.append(str(r['_id']))
-            results['count'] = len(filterlist)
+            #fily = {'id': 1, 'tlp':1,'source':1}
+            #filterlist = []
+            #query['source.name'] = {'$in': sourcefilt}
+            #resy = col.find(query, fily).sort(*sort)
+            #for r in resy:
+            #    if user.check_dict_source_tlp(r):
+            #        filterlist.append(str(r['_id']))
+            #results['count'] = len(filterlist)
+            #if count:
+            #    results['result'] = "OK"
+            #    return results
+
+            #docs = col_obj.objects.filter(id__in=filterlist).\
+            tlp_filter_query = user.filter_dict_source_tlp(query)
+            docs = col_obj.objects.filter(__raw__=tlp_filter_query).\
+                                            order_by(*sort).skip(skip).\
+                                            only(*projection).limit(limit)
+            results['count'] = docs.count()
             if count:
                 results['result'] = "OK"
                 return results
-
-            docs = col_obj.objects.filter(id__in=filterlist).\
-                                            order_by(*sort).skip(skip).\
-                                            only(*projection).limit(limit)
 
         for doc in docs:
             if hasattr(doc, "sanitize_sources"):

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -921,26 +921,38 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
                         return True
         return False
 
-    def check_dict_source_tlp(self, object):
+    def filter_dict_source_tlp(self, filter_dict):
         """
         pymongo dict version of check_source_tlp()
         """
         if not object:
             return False
+        user_source_list_red = [x.name for x in filter(lambda us: us.tlp_red, self.acl.get('sources'))]
+        user_source_list_amber = [x.name for x in filter(lambda us: us.tlp_amber, self.acl.get('sources'))]
+        user_source_list_green = [x.name for x in filter(lambda us: us.tlp_green, self.acl.get('sources'))]
+        source_tlp_filter = {'$elemMatch': {'$or': [{'instances.tlp': 'white'}, # Consider 'TLP white' open to all, even users who don't have permission on the source
+                                                    # If the TLP isn't specified on any source instance, treat it like TLP Red
+                                                    {'name': {'$in': user_source_list_red}, 'instances': {'$elemMatch': {'tlp': {'$exists': False}}}},
+                                                    # Check the user can see TLP:Red for a source, and see if this intel was released at that level (or below)
+                                                    {'name': {'$in': user_source_list_red}, 'instances.tlp': 'red'},
+                                                    # Check the user can see TLP:Amber for a source, and see if this intel was released at that level (or below)
+                                                    {'name': {'$in': user_source_list_amber}, 'instances.tlp': 'amber'},
+                                                    # Check the user can see TLP:Green for a source, and see if this intel was released at that level
+                                                    {'name': {'$in': user_source_list_green}, 'instances.tlp': 'green'}]}}
+        return {'$and': [filter_dict, {'source': source_tlp_filter}]} # Merge these as an $and relationship with the original query
 
-        user_source_objects = self.acl.get('sources')
-        for source in object['source']:
-            for instance in source['instances']:
-                itlp = instance.get('tlp', 'red')
-                if itlp == "white":
-                    return True
-                elif itlp == "red" and [True for usource in user_source_objects if usource.name == source['name'] and usource.tlp_red and usource.read]:
-                    return True
-                elif itlp == "amber" and [True for usource in user_source_objects if usource.name == source['name']  and usource.tlp_amber and usource.read]:
-                    return True
-                elif itlp == "green" and [True for usource in user_source_objects if usource.name == source['name']  and usource.tlp_green and usource.read]:
-                    return True
-        return False
+        #for source in object['source']:
+        #    for instance in source['instances']:
+        #        itlp = instance.get('tlp', 'red')
+        #        if itlp == "white":
+        #            return True
+        #        elif itlp == "red" and [True for usource in user_source_objects if usource.name == source['name'] and usource.tlp_red and usource.read]:
+        #            return True
+        #        elif itlp == "amber" and [True for usource in user_source_objects if usource.name == source['name']  and usource.tlp_amber and usource.read]:
+        #            return True
+        #        elif itlp == "green" and [True for usource in user_source_objects if usource.name == source['name']  and usource.tlp_green and usource.read]:
+        #            return True
+        #return False
 
     def check_source_write(self, source):
         """

--- a/crits/core/user.py
+++ b/crits/core/user.py
@@ -927,9 +927,9 @@ class CRITsUser(CritsDocument, CritsSchemaDocument, Document):
         """
         if not object:
             return False
-        user_source_list_red = [x.name for x in filter(lambda us: us.tlp_red, self.acl.get('sources'))]
-        user_source_list_amber = [x.name for x in filter(lambda us: us.tlp_amber, self.acl.get('sources'))]
-        user_source_list_green = [x.name for x in filter(lambda us: us.tlp_green, self.acl.get('sources'))]
+        user_source_list_red = [x.name for x in filter(lambda us: us.tlp_red and us.read, self.acl.get('sources'))]
+        user_source_list_amber = [x.name for x in filter(lambda us: us.tlp_amber and us.read, self.acl.get('sources'))]
+        user_source_list_green = [x.name for x in filter(lambda us: us.tlp_green and us.read, self.acl.get('sources'))]
         source_tlp_filter = {'$elemMatch': {'$or': [{'instances.tlp': 'white'}, # Consider 'TLP white' open to all, even users who don't have permission on the source
                                                     # If the TLP isn't specified on any source instance, treat it like TLP Red
                                                     {'name': {'$in': user_source_list_red}, 'instances': {'$elemMatch': {'tlp': {'$exists': False}}}},


### PR DESCRIPTION
First run at attempt to fix Issue #913 and push the TLP filters to the database query, instead of
doing it on the server-side. This is especially expensive because it causes
paginated views to fetch all elements from a collection. We have over 2M objects
in some collections, and this made the application unusable, regardless of
hardware, post tlp-addition.

I have left the "old code" in place, but commented out, so that the crew
can compare the intent/logic of the original implementation with my refactor.

Once I get thumbs-up, or tweaks that correct errors I've introduced, I'll
commit the removal of the commented-out code.

It is super-fast now, btw.