### PR TITLE
Make maximum CSV rows configurable

### DIFF
--- a/crits/config/config.py
+++ b/crits/config/config.py
@@ -38,6 +38,7 @@ class CRITsConfig(CritsDocument, Document):
     # for historical reasons.
     crits_version = StringField(required=True,
                                 default=settings.CRITS_VERSION)
+    csv_max = IntField(default=25000)
     debug = BooleanField(default=True)
     enable_dt = BooleanField(default=False)
     depth_max = IntField(default=10)

--- a/crits/config/forms.py
+++ b/crits/config/forms.py
@@ -229,6 +229,11 @@ class ConfigDownloadForm(forms.Form):
         help_text='Maximum relationships an object can have while downloading',
         initial='50',
         required=False)
+    csv_max = forms.CharField(
+        widget=forms.TextInput,
+        help_text='Maximum number of rows in CSV files',
+        initial='25000',
+        required=False)
     def __init__(self, *args, **kwargs):
         super(ConfigDownloadForm, self).__init__(*args, **kwargs)
 

--- a/crits/config/templates/config.html
+++ b/crits/config/templates/config.html
@@ -283,7 +283,7 @@
         {% if GeneralACL.CONTROL_PANEL_SYSTEM_READ|has_access_to:user %}
           <div id='systemContainer' class='rightContent forceInvisible'>
                  <div id="config_results"></div>
-              <form id="config_form" action='{% url "crits-config-views-modify_config" %}' method='POST'>
+              <form id="config_form" action='{% url "crits-config-views-modify_config" %}' method='POST'> {% csrf_token %}
                   <div id='CRITsTab' class='box forceInvisible'>
                       <table class="systemTable">{{ config_CRITs_form.as_table }}</table>
                   </div>

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -2053,7 +2053,7 @@ def data_query(col_obj, user, limit=25, skip=0, sort=[], query={},
     results['result'] = "OK"
     return results
 
-def csv_query(col_obj,user,fields=[],limit=10000,skip=0,sort=[],query={}):
+def csv_query(col_obj,user,fields=[],limit=0,skip=0,sort=[],query={}):
     """
     Runs query and returns items in CSV format with fields as row headers
 
@@ -2072,6 +2072,15 @@ def csv_query(col_obj,user,fields=[],limit=10000,skip=0,sort=[],query={}):
     :param query: MongoDB query
     :type query: dict
     """
+
+    # Use maximum row count from config if an invalid value is given
+    crits_config = CRITsConfig.objects().first()
+    if crits_config:
+        csv_max = crits_config.csv_max
+    else:
+        csv_max = 25000 # Arbitrary Default
+    if not isinstance(limit, int) or limit < 1 or limit > csv_max:
+        limit = csv_max
 
     results = data_query(col_obj, user=user, limit=limit,
                               skip=skip, sort=sort, query=query,
@@ -2120,7 +2129,7 @@ def parse_query_request(request,col_obj):
 
         resp['fields'] = goodfields
     resp['sort'] = request.GET.get('sort',[])
-    resp['limit'] = int(request.GET.get('limit',10000))
+    resp['limit'] = int(request.GET.get('limit', 0))
     resp['skip'] = int(request.GET.get('skip',0))
     return resp
 


### PR DESCRIPTION
This will allow an admin to choose the default/maximum number of rows for downloads to CSV. This is the limit used when a user clicks the "CSV" button at the top-right of a jTable.  Historically this was arbitrarily limited to 10000 rows, but now can be adjusted in the control panel.

@mgoffin: Let me know if this aligns with what you were expecting following our conversation.