### PR TITLE
Fix undefined dictionary "retVal"

### DIFF
--- a/crits/signatures/handlers.py
+++ b/crits/signatures/handlers.py
@@ -426,9 +426,11 @@ def handle_signature_file(data, source_name, user=None,
     if related_id and related_type:
         related_obj = class_from_id(related_type, related_id)
         if not related_obj:
-            retVal['success'] = False
-            retVal['message'] = 'Related Object not found.'
-            return retVal
+            status = {
+                'success':   False,
+                'message':  'Related Object not found.'
+            }
+            return status
 
     signature.save(username=user.username)
 


### PR DESCRIPTION
The dictionary "retVal" did not exist, causing error `NameError: global name 'retVal' is not defined`.