### PR TITLE
Fix problem with "status" display ACL

### DIFF
--- a/crits/indicators/templates/indicator_detail.html
+++ b/crits/indicators/templates/indicator_detail.html
@@ -161,7 +161,7 @@
             </div>
         </td>
         </tr>
-        {% if INDICATORACL|has_access_to:user.STATUS_READ|has_access_to:user %}
+        {% if IndicatorACL.STATUS_READ|has_access_to:user %}
           <tr>
             <td class="key">Status
                 <span style="float: right;" class="object_status_response"></span>


### PR DESCRIPTION
See line 164 - the old text was:
{% if INDICATORACL|has_access_to:user.STATUS_READ|has_access_to:user %}
and *should* read:
{% if IndicatorACL.STATUS_READ|has_access_to:user %}