### PR TITLE
Add 'c-field__eq' support to API, and fix de-quote

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -475,7 +475,7 @@ class CRITsAPIResource(MongoEngineResource):
                 except ValueError:
                     op_index = None
                 if op_index is not None:
-                    if op in ('$gt', '$gte', '$lt', '$lte', '$ne', '$in', '$nin', '$exists'):
+                    if op in ('$gt', '$gte', '$lt', '$lte', '$ne', '$in', '$nin', '$exists', '$eq'):
                         val = v
                         if field in ('created', 'modified'):
                             try:
@@ -512,7 +512,10 @@ class CRITsAPIResource(MongoEngineResource):
                                 except:
                                     val = None
                         if val or val == 0:
-                            querydict[field] = {op: val}
+                            if op == '$eq':
+                                querydict[field] = remove_quotes(val)
+                            else:
+                                querydict[field] = {op: remove_quotes(val)}
                 elif field in ('size', 'schema_version'):
                     querydict[field] = v_int
                 elif field in ('created', 'modified'):


### PR DESCRIPTION
The <code>querydict[field] = {op: val}</code> operation seems to be failing if the
user requests <code>?c-value__ne=something</code>, and the fix appears to be
<code>remove_quotes(val)</code>. So fixing this.

Additionally, when making an API call with <code>regex=1</code>, there didn't appear
to be a mechanism to force *some* fields to be non-regex searches. Since
this is a potential query optimization (limiting what regex gets applied
to), I added support for <code>c-field__eq</code>, which will use the existing "regex
override" logic to force any specific field(s) to be equality-matched, rather
than regex matched.

Using the documentation
https://docs.mongodb.com/manual/reference/operator/query/eq/#op._S_eq
I simplify <code>{'field': {'$eq': remove_quotes(val)}}</code> to be
<code>{'field': remove_quotes(val)}</code> because the docs say the two are
equivalent anyhow, and this would reduce the data size when querying
mongodb, for larger queries.