### PR TITLE
Include "user" parameter in "activity_add" function call

### DIFF
--- a/crits/indicators/api.py
+++ b/crits/indicators/api.py
@@ -170,7 +170,7 @@ class IndicatorActivityResource(CRITsAPIResource):
                     'end_date': end_date,
                     'description': description,
                     'date': datetime.datetime.now()}
-        result = activity_add(object_id, activity)
+        result = activity_add(object_id, activity, user)
         if not result['success']:
             content['message'] = result['message']
             self.crits_response(content)


### PR DESCRIPTION
The API call to add data to the 'activity' field in Indicators (by POSTing to api/v1/indicator_activity) is currently not working properly because it is missing the required parameter "user"; Simple commit to add that parameter to the activity_add function call (see /crits/crits/indicators/handlers.py line 1061)