### PR TITLE
Occasional Undefined Function "processObjectTypeCellChange" Error

### DIFF
--- a/crits/objects/templates/bulk_add_object_inline.html
+++ b/crits/objects/templates/bulk_add_object_inline.html
@@ -34,11 +34,11 @@
 
     {% with height='undefined' navigation_control='false' %}
     if(typeof(Handsontable) === 'undefined') {
+        {% include "handsontable.js" with formdict=formdict prefix="Inline" %}
+
         $.when($.getScript("/js/handsontable/jquery.handsontable.full.js"),
                $.getScript("{{ STATIC_URL }}js/bulk_add_default.js")).done(function() {
             var defaultInlineTableName = '{{ table_name }}';
-
-            {% include "handsontable.js" with formdict=formdict prefix="Inline" %}
 
             {% if not is_prevent_initial_table %}
                 initializeHandsOnTableInline('handsontable_{{ table_name }}', '{{ table_name }}');


### PR DESCRIPTION
The "bulk_add_default.js" file has a call to function `processObjectTypeCellChange` which is implemented in file "handsontable.js", but "bulk_add_default.js" is loaded before "handsontable.js", occasionally leading to a `processObjectTypeCellChange is not a function` error.

Including "handsontable.js" earlier addresses this error and doesn't appear to hurt anything.