### PR TITLE
Fix case where XHR login reauths an existing session

### DIFF
--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -350,7 +350,7 @@ def login(request):
     user = request.user
 
     # Is the user already authenticated?
-    if (request.user.is_authenticated if django_version >= (1, 10) else request.user.is_authenticated()) and user.has_access_to(GeneralACL.WEB_INTERFACE):
+    if (request.user.is_authenticated if django_version >= (1, 10) else request.user.is_authenticated()) and user.has_access_to(GeneralACL.WEB_INTERFACE) and not request.is_ajax:
         resp = validate_next(next_url)
         if not resp['success']:
             return render(request, 'error.html',


### PR DESCRIPTION
When XMLHttpRequest attempts to authenticate an already-logged-in
session, the response is rendered as HTML. This causes the "user is
already authenticated" session cookie check to only occur on the /login/
route view when the request is not Ajax. If it is Ajax, the code
proceeds to create a new session and return JSON code. The HTML response
in the current behavior causes anything expecting JSON to generate a
parsing error.