### PR TITLE
Parameter fix for "handle_eml" call in emails/api

### DIFF
--- a/crits/emails/api.py
+++ b/crits/emails/api.py
@@ -94,8 +94,8 @@ class EmailResource(CRITsAPIResource):
                 content['message'] = 'No file uploaded.'
                 self.crits_response(content)
             filedata = file_.read()
-            result = handle_eml(filedata, source, reference,
-                                user, 'EML Upload' + method, tlp=tlp, campaign=campaign,
+            result = handle_eml(data=filedata, sourcename=source, reference=reference,
+                                user=user, method='EML Upload' + method, tlp=tlp, campaign=campaign,
                                 confidence=confidence, bucket_list=bucket_list, ticket=ticket)
         if type_ == 'msg':
             raw_email = bundle.data.get('filedata', None)


### PR DESCRIPTION
When uploading an email in the EML format to the CRITS database via the API the 'handle_eml' function passed the parameter in the incorrect order leading to the return of the error message "handle_eml() got multiple values for keyword argument 'tlp'". This fix that by passing the parameters explicitly during the function call so the correct data goes to the correct parameters in the handle_eml function. This fixes the error in #952 