### PR TITLE
Change bundle.get source to match other TLOs

### DIFF
--- a/crits/emails/api.py
+++ b/crits/emails/api.py
@@ -70,7 +70,7 @@ class EmailResource(CRITsAPIResource):
         result = None
 
         # Extract common information
-        source = bundle.data.get('source_name', None)
+        source = bundle.data.get('source', None)
         method = bundle.data.get('source_method', '')
         reference = bundle.data.get('source_reference', None)
         tlp = bundle.data.get('source_tlp', 'amber')


### PR DESCRIPTION
In emails/api the bundle.get() function call for the Source attempted to get data from a field called 'source_name' but in every other TLO POST the bundle attempts to get the Source from a field called 'source' and in the API Documentation one of the noted common POST parameters is 'source' not 'source_name' therefore the email API bundle call should conform to the standard and attempt to get the standard 'source' field for the Source NOT 'source_name'