### PR TITLE
Attempt to chase a bug I introduced with the __ne support

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -516,10 +516,12 @@ class CRITsAPIResource(MongoEngineResource):
                                 except:
                                     val = None
                         if val or val == 0:
+                            if not isinstance(val, list):
+                                val = remove_quotes(val)
                             if op == '$eq':
-                                querydict[field] = remove_quotes(val)
+                                querydict[field] = val
                             else:
-                                querydict[field] = {op: remove_quotes(val)}
+                                querydict[field] = {op: val}
                 elif field in ('size', 'schema_version'):
                     querydict[field] = v_int
                 elif field in ('created', 'modified'):
@@ -547,7 +549,7 @@ class CRITsAPIResource(MongoEngineResource):
             querydict_tlp_filter = user.filter_dict_source_tlp(querydict)
         else:
             querydict_tlp_filter = querydict
-            
+
         if only or exclude:
             required = [k for k,f in klass._fields.iteritems() if f.required]
         if only:


### PR DESCRIPTION
Basically, there are some cases where the value of a field in the query
string is represented as a comma-separated list of values. There is code
present earlier in this function to identify these and do the
tokenize-and-listify operation. However, that renders val as a list,
rather than string, type by the time it gets to the code to populate the
field constraint in the query dict (which is coded to call
remove_quotes(val) ).

So the solution is to test whether val is a list, and if it isn't, run
the remove_quotes(val). Otherwise, just pass the already-decoded list as
the rvalue in the assignment.