### PR TITLE
Call remove_quotes only if val is a str

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -516,7 +516,7 @@ class CRITsAPIResource(MongoEngineResource):
                                 except:
                                     val = None
                         if val or val == 0:
-                            if not isinstance(val, list):
+                            if isinstance(val, str):
                                 val = remove_quotes(val)
                             if op == '$eq':
                                 querydict[field] = val


### PR DESCRIPTION
In the cases where val was a str type, this would always run the
remove_quotes function. However, if the val was anything other than a
list type (such as a datetime), it would also attempt this translation.
This change limits the translation to only occur on str types, which I
think is the appropriate action.