### PR TITLE
Fix setconfig called via manage.py

### DIFF
--- a/crits/core/management/commands/setconfig.py
+++ b/crits/core/management/commands/setconfig.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                         'database, even though defaults specified by the ' +
                         'document in Python is correct. This has the third ' +
                         'highest precedence over other options.'),
-
+        parser.add_argument('args', nargs='*')
         args = """<configuration option> <value>
 
                Available configuration options:


### PR DESCRIPTION
setconfig command is broken after move to Django 1.8+, which required replacing optparse with Django provided argparse based solution. It looks like I missed one important piece...

How it should be:
$ python manage.py setconfig debug False
A CRITs configuration already exists. Skipping default creation.
Setting [debug] to a value of [False]
Saving CRITs configuration.

How it is now:
$ python manage.py setconfig debug False
usage: manage.py setconfig [-h] [--version] [-v {0,1,2,3}]
                           [--settings SETTINGS] [--pythonpath PYTHONPATH]
                           [--traceback] [--no-color] [--reset_config]
                           [--create_config] [--reinsert_config]
manage.py setconfig: error: unrecognized arguments: debug False

After the fix:
$ python manage.py setconfig debug False
A CRITs configuration already exists. Skipping default creation.
Setting [debug] to a value of [False]
Saving CRITs configuration.

mongo
> db.config.find({},{debug:1})
{ "_id" : ObjectId("5bc207723b7750687d64106b"), "debug" : false }