### PR TITLE
Fix the issue with the latest mongoengine

### DIFF
--- a/crits/services/analysis_result.py
+++ b/crits/services/analysis_result.py
@@ -88,7 +88,7 @@ class AnalysisResult(CritsDocument, CritsSchemaDocument, CritsDocumentFormatter,
     log = ListField(EmbeddedDocumentField(EmbeddedAnalysisResultLog))
     object_type = StringField(required=True)
     object_id = StringField(required=True)
-    results = ListField(DynamicField(DictField))
+    results = ListField(DynamicField())
     service_name = StringField()
     source = StringField()
     start_date = StringField()


### PR DESCRIPTION
On mongoengine 0.16.x we get the following error:
...
    from crits.services.analysis_result import EmbeddedAnalysisResultLog, AnalysisConfig
  File "/data/crits/crits/services/analysis_result.py", line 31, in <module>
    Document):
  File "/data/crits/crits/services/analysis_result.py", line 91, in AnalysisResult
    results = ListField(DynamicField(DictField))
  File "/data/crits/venv2/local/lib/python2.7/site-packages/mongoengine/base/fields.py", line 89, in __init__
    raise TypeError('db_field should be a string.')
TypeError: db_field should be a string.

This change has already been implemented on 4-master.