### PR TITLE
Switch SESSION_ENGINE to signed_cookies on stable_4

### DIFF
--- a/crits/settings.py
+++ b/crits/settings.py
@@ -479,7 +479,8 @@ if old_mongoengine:
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
 
-    SESSION_ENGINE = 'mongoengine.django.sessions'
+    SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+    #SESSION_ENGINE = 'mongoengine.django.sessions'
 
     SESSION_SERIALIZER = 'mongoengine.django.sessions.BSONSerializer'
 
@@ -536,7 +537,8 @@ else:
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
-    SESSION_ENGINE = 'django_mongoengine.sessions'
+    SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+    #SESSION_ENGINE = 'django_mongoengine.sessions'
 
     SESSION_SERIALIZER = 'django_mongoengine.sessions.BSONSerializer'
 


### PR DESCRIPTION
Backport from master to avoid of some django issues.
The story is as follows:
After playing recently with stable_4, I ran into issues with how sessions are handled between different versions of the Django (mainly 1.7-1.8-1.9 IIRC). As a part of the fix that I made to get the Django 1.8 to work had to do with overloading the one of the functions with a functional equivalent from the earlier version of Django. That was done due to errors that were popping up when the Django would be updated or downgraded and there would be still some session data in the database causing the exceptions to be thrown. To avoid this altogether, I've switched master to use signed_cookies, this patch does the same for  stable_4.