### PR TITLE
Use PasswordInput widget for ldap_bind_password in stable_4

### DIFF
--- a/crits/config/forms.py
+++ b/crits/config/forms.py
@@ -92,7 +92,7 @@ class ConfigLDAPForm(forms.Form):
         required=False,
         help_text=('bind_dn for binding to LDAP'))
     ldap_bind_password = forms.CharField(
-        widget=forms.TextInput,
+        widget=forms.PasswordInput(render_value=True),
         required=False,
         help_text=('bind_password for binding to LDAP'))
     ldap_usercn = forms.CharField(


### PR DESCRIPTION
To adhere to best practices and avoid audit findings... Use PasswordInput widget for ldap_bind_password.