### PR TITLE
Avoid exception at download if there are no docs to return

### DIFF
--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -1212,6 +1212,9 @@ def download_object_handler(total_limit, depth_limit, rel_limit, rst_fmt,
         fname = "CRITs_%s_%s_%s" % (obj_type, obj_id, stamp)
     else:
         fname = "CRITs_%s" % stamp
+        
+    if not json_docs: # Fail if no docs to return
+        return {'success': False}
     if rst_fmt != 'zip': # JSON File
         return {'success': True,
                 'data': "[%s]" % ",".join(doc[2] for doc in json_docs),


### PR DESCRIPTION
When downloading a TLO, If the user selects options that result in nothing to download, and the selected Result Format is "zip", an exception occurs. This fix checks for an empty list of json_docs and produces an appropriate error message instead.