### PR TITLE
Improve performance of bucket_counts management command

### DIFF
--- a/crits/core/management/commands/bucket_counts.py
+++ b/crits/core/management/commands/bucket_counts.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from crits.core.bucket import Bucket
 from crits.core.class_mapper import class_from_type
+from crits.core.mongo_tools import mongo_connector
 
 class Command(BaseCommand):
     """
@@ -15,24 +16,30 @@ class Command(BaseCommand):
 
         buckets = {}
 
-        types = ['Actor', 'Campaign', 'Certificate', 'Domain', 'Email', 'Event',
-                 'Indicator', 'IP', 'PCAP', 'RawData', 'Signature', 'Sample', 'Target']
+        pipeline = [
+            {'$match': {'$and': [{'bucket_list': {'$ne': []}},
+                                 {'bucket_list': {'$exists': True}}]}}, # only TLOs with buckets
+            {'$unwind': '$bucket_list'}, # split each bucket out of list
+            {'$match': {'bucket_list': {'$ne': ''}}}, # ignore any empty string buckets
+            {'$group': {'_id': {'tag': '$bucket_list', 'id': '$_id'}}}, # get unique per TLO
+            {'$group': {'_id': '$_id.tag', 'count': {'$sum': 1}}}, # total bucket counts
+        ]
 
-        for otype in types:
-            klass = class_from_type(otype)
-            if not klass:
-                continue
-            objs = klass.objects().only('bucket_list')
-            for obj in objs:
-                for bucket in obj.bucket_list:
-                    if not bucket:
-                        continue # Avoid empty strings
-                    if bucket not in buckets:
-                        buckets[bucket] = Bucket()
-                        buckets[bucket].name = bucket
-                        setattr(buckets[bucket], otype, 1)
-                    else:
-                        buckets[bucket][otype] += 1
+        tlo_types = [
+            'Actor', 'Campaign', 'Certificate', 'Domain', 'Email',
+            'Event', 'Indicator', 'IP', 'PCAP', 'RawData', 'Signature',
+            'Sample', 'Target',
+        ]
+
+        for tlo_type in tlo_types:
+            coll = class_from_type(tlo_type)._meta['collection']
+            result = mongo_connector(coll).aggregate(pipeline)
+            for x in result['result']:
+                bucket = x['_id']
+                if bucket not in buckets:
+                    buckets[bucket] = Bucket()
+                    buckets[bucket].name = bucket
+                setattr(buckets[bucket], tlo_type, x['count'])
 
         # Drop all existing buckets
         Bucket.objects().delete_one()


### PR DESCRIPTION
The bucket_counts management command was looping through every TLO to count the buckets.  This was taking minutes to complete with a medium-sized data set.  Using MongoDB's aggregate function, it now takes seconds.  Completes over 30x faster with our data set.