### PR TITLE
Replacing len() on Querysets with .count() to make the DB do the heavy lifting 

### DIFF
--- a/crits/certificates/handlers.py
+++ b/crits/certificates/handlers.py
@@ -345,7 +345,7 @@ def handle_cert_file(filename, data, source_name, user=None,
     cert.reload()
 
     # run certificate triage
-    if len(AnalysisResult.objects(object_id=str(cert.id))) < 1 and data:
+    if AnalysisResult.objects(object_id=str(cert.id)).count() < 1 and data:
         run_triage(cert, user)
 
     # update relationship if a related top-level object is supplied

--- a/crits/core/handlers.py
+++ b/crits/core/handlers.py
@@ -627,7 +627,7 @@ def does_source_exist(source, active=False):
     query = {'name': source}
     if active:
         query['active'] = 'on'
-    if len(SourceAccess.objects(__raw__=query)) > 0:
+    if SourceAccess.objects(__raw__=query).count() > 0:
         return True
     else:
         return False
@@ -982,6 +982,7 @@ def alter_bucket_list(obj, buckets, val):
     # We are using mongo_connector here because mongoengine does not have
     # support for a setOnInsert option. If mongoengine were to gain support
     # for this we should switch to using it instead of pymongo here.
+    ###TODO: SetOnInsert is supported since mongoengine 0.8.0 (see commits #308/#309)
     buckets_col = mongo_connector(settings.COL_BUCKET_LISTS)
     for name in buckets:
         buckets_col.update({'name': name},

--- a/crits/core/management/commands/create_default_collections.py
+++ b/crits/core/management/commands/create_default_collections.py
@@ -68,7 +68,7 @@ def populate_actions(drop):
     actions = ['Blocked Outbound At Firewall', 'Blocked Outbound At Desktop Firewall']
     if drop:
         Action.drop_collection()
-    if len(Action.objects()) < 1:
+    if Action.objects().count() < 1:
         for action in actions:
             ia = Action()
             ia.name = action
@@ -90,7 +90,7 @@ def populate_raw_data_types(drop):
     data_types = ['Text', 'JSON']
     if drop:
         RawDataType.drop_collection()
-    if len(RawDataType.objects()) < 1:
+    if RawDataType.objects().count() < 1:
         for data_type in data_types:
             dt = RawDataType()
             dt.name = data_type
@@ -112,7 +112,7 @@ def populate_signature_types(drop):
     data_types = ['Bro', 'Snort', 'Yara']
     if drop:
         SignatureType.drop_collection()
-    if len(SignatureType.objects()) < 1:
+    if SignatureType.objects().count() < 1:
         for data_type in data_types:
             dt = SignatureType()
             dt.name = data_type

--- a/crits/notifications/handlers.py
+++ b/crits/notifications/handlers.py
@@ -511,14 +511,16 @@ def get_user_notifications(username, count=False, newer_than=None):
     n = None
 
     if newer_than is None or newer_than == None:
-        n = Notification.objects(users=username).order_by('-created')
+        if count:
+            n = Notification.objects(users=username).order_by('-created').count()
+        else:
+            n = Notification.objects(users=username).order_by('-created')
     else:
-        n = Notification.objects(Q(users=username) & Q(created__gt=newer_than)).order_by('-created')
-
-    if count:
-        return len(n)
-    else:
-        return n
+        if count:
+            n = Notification.objects(Q(users=username) & Q(created__gt=newer_than)).order_by('-created').count()
+        else:
+            n = Notification.objects(Q(users=username) & Q(created__gt=newer_than)).order_by('-created')
+    return n
 
 __supported_notification_types__ = {
     'Actor': 'name',

--- a/crits/objects/handlers.py
+++ b/crits/objects/handlers.py
@@ -368,7 +368,7 @@ def delete_object_file(value):
     query = {'objects.value': value}
     for obj in obj_list:
         obj_class = class_from_type(obj)
-        count += len(obj_class.objects(__raw__=query))
+        count += obj_class.objects(__raw__=query).count()
         if count > 1:
             break
     else:

--- a/crits/raw_data/handlers.py
+++ b/crits/raw_data/handlers.py
@@ -110,7 +110,7 @@ def get_raw_data_details(_id, user):
                 'value': raw_data.id
         }
 
-        versions = len(RawData.objects(link_id=raw_data.link_id).only('id'))
+        versions = RawData.objects(link_id=raw_data.link_id).only('id').count()
 
         #comments
         comments = {'comments': raw_data.get_comments(),
@@ -437,7 +437,7 @@ def handle_raw_data_file(data, source_name, user=None,
                                                       analyst=user.username)
 
 
-    raw_data.version = len(RawData.objects(link_id=link_id)) + 1
+    raw_data.version = RawData.objects(link_id=link_id).count() + 1
 
     if bucket_list:
         raw_data.add_bucket_list(bucket_list, user)

--- a/crits/samples/handlers.py
+++ b/crits/samples/handlers.py
@@ -1007,7 +1007,7 @@ def handle_file(filename, data, source, source_method='', source_reference='',
         sample.reload()
 
         # run sample triage:
-        if len(AnalysisResult.objects(object_id=str(sample.id))) < 1:
+        if AnalysisResult.objects(object_id=str(sample.id)).count() < 1:
             run_triage(sample, user)
 
             if is_return_only_md5 == False:

--- a/crits/signatures/handlers.py
+++ b/crits/signatures/handlers.py
@@ -110,7 +110,7 @@ def get_signature_details(_id, user):
                 'value': signature.id
         }
 
-        versions = len(Signature.objects(link_id=signature.link_id).only('id'))
+        versions = Signature.objects(link_id=signature.link_id).only('id').count()
 
         #comments
         comments = {'comments': signature.get_comments(),
@@ -397,7 +397,7 @@ def handle_signature_file(data, source_name, user=None,
             if isinstance(s, EmbeddedSource):
                 signature.add_source(s, method=source_method, reference=source_reference, source_tlp=source_tlp)
 
-    signature.version = len(Signature.objects(link_id=link_id)) + 1
+    signature.version = Signature.objects(link_id=link_id).count() + 1
 
     if link_id:
         signature.link_id = link_id


### PR DESCRIPTION
Replacing some len() with .count(). It makes DB do work rather than Python. This also should reduce lag in those places, as Python will not pull down the results of the query, and will not have to iterate through them to count them.

Also added a note about SetOnInsert being supported by Mongoengine 8.0.0,
so that the query can be changed to run under mongoengine rather than PyMongo