### PR TITLE
Fix Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get install -y sudo
 RUN apt-get install -y software-properties-common
 
 # Clone the repo
-#RUN git clone --depth 1 https://github.com/crits/crits.git 
-COPY . crits
+RUN git clone --depth 1 https://github.com/crits/crits.git 
 
 WORKDIR crits
 # Install the dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ RUN TERM=xterm sh ./script/bootstrap < docker_inputs
 RUN sh contrib/mongo/mongod_start.sh && python manage.py users -R UberAdmin -u admin -p "pass1PASS123!" -s -i -a -e admin@crits.crits -f "first" -l "last" -o "no-org"
 
 EXPOSE 8080
+
 CMD sh contrib/mongo/mongod_start.sh && python manage.py runserver 0.0.0.0:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get install -y sudo
 RUN apt-get install -y software-properties-common
 
 # Clone the repo
-RUN git clone --depth 1 https://github.com/crits/crits.git 
+#RUN git clone --depth 1 https://github.com/crits/crits.git 
+COPY . crits
 
 WORKDIR crits
 # Install the dependencies
@@ -25,5 +26,4 @@ RUN TERM=xterm sh ./script/bootstrap < docker_inputs
 RUN sh contrib/mongo/mongod_start.sh && python manage.py users -R UberAdmin -u admin -p "pass1PASS123!" -s -i -a -e admin@crits.crits -f "first" -l "last" -o "no-org"
 
 EXPOSE 8080
-
 CMD sh contrib/mongo/mongod_start.sh && python manage.py runserver 0.0.0.0:8080

--- a/contrib/mongo/mongod_start.sh
+++ b/contrib/mongo/mongod_start.sh
@@ -7,5 +7,5 @@
 if [ -f /usr/local/bin/mongod ]; then
   /usr/local/bin/mongod --fork --logpath /data/logs/mongodb.log --logappend --nohttpinterface --dbpath /data/db --smallfiles
 else
-  mongod --fork --logpath /data/logs/mongodb.log --logappend --nohttpinterface --dbpath /data/db --smallfiles
+  mongod --fork --logpath /data/logs/mongodb.log --logappend --dbpath /data/db --smallfiles
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -265,9 +265,6 @@ ubuntu_install()
     printf "${INFO}Installing dependencies with apt-get${END}\n"
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
     echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-    #sudo -E apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-    #echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-    #sudo -E add-apt-repository universe
     sudo -E apt-get update
     sudo -E DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libjpeg-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep upx zip libssl-dev
     sudo ldconfig

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -263,11 +263,13 @@ exit_restart()
 ubuntu_install()
 {
     printf "${INFO}Installing dependencies with apt-get${END}\n"
-    sudo -E apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-    echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-    sudo -E add-apt-repository universe
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+    echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+    #sudo -E apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+    #echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+    #sudo -E add-apt-repository universe
     sudo -E apt-get update
-    sudo -E apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libjpeg-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep upx zip libssl-dev
+    sudo -E DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing build-essential curl git libevent-dev libz-dev libjpeg-dev libfuzzy-dev libldap2-dev libpcap-dev libpcre3-dev libsasl2-dev libxml2-dev libxslt1-dev libyaml-dev mongodb-org numactl p7zip-full python-dev python-pip ssdeep upx zip libssl-dev
     sudo ldconfig
 }
 


### PR DESCRIPTION
Hi there 👋 

I encountered a few issues when trying to build the Docker image and wanted to post up a fix. Specifically, my changes fix the following:

* The `--nohttpinterface` option doesn't appear to be valid for the version of MongoDB installed with this Docker image. I'm not a Mongo expert, so I've just removed the flag. It's unclear if there's a substitution for it, or if this is one of those things that's disabled by default now.
* I've updated the MongoDB installation commands to match the [current guidelines](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/), since these were broken in the current Dockerfile.

I hope this helps!