### PR TITLE
Fix bug where unauthorized users could interact with source_access

### DIFF
--- a/crits/core/views.py
+++ b/crits/core/views.py
@@ -714,6 +714,7 @@ def source_releasability(request):
         error = "Expected AJAX POST!"
         return render(request, "error.html", {"error" : error })
 
+@user_passes_test(user_can_view_data)
 def source_access(request):
     """
     Modify a user's profile. Should be an AJAX POST.


### PR DESCRIPTION
An attacker can make requests directly to the administrator control panel without going through the user interface. In doing so there is no validation that the person using the control panel is authenticated. As a result, an attacker can create a request to create a new user (or modify an existing user) with the highest level of permissions while unauthenticated. 

Adding the user_can_view test resolves this issue.